### PR TITLE
Warnings and fallback to 1 per month if not recurring and seats should be

### DIFF
--- a/includes/edit-level.php
+++ b/includes/edit-level.php
@@ -105,6 +105,9 @@ function pmprogroupacct_pmpro_membership_level_before_content_settings( $level )
 								<option value="fixed" <?php selected( 'fixed', $settings['pricing_model'] ); ?>><?php esc_html_e( 'Per Seat - Set a specific price per additional seat.', 'pmpro-group-accounts' ); ?></option>
 							</select>
 							<p class="description"><?php esc_html_e( 'The pricing model to use for purchasing seats.', 'pmpro-group-accounts' ); ?></p>
+							<div id="pmprogroupacct_pricing_model_warning_free_level" style="display: none;" class="pmpro_message pmpro_alert">
+								<p><?php esc_html_e( 'WARNING: This level does not have any pricing set up. We highly recommend that you set up an initial payment or recurring billing for a better checkout experience.', 'pmpro-group-accounts' ); ?></p>
+							</div>
 						</td>
 					</tr>
 					<tr class="pmprogroupacct_setting pmprogroupacct_pricing_setting pmprogroupacct_pricing_setting_fixed">
@@ -135,6 +138,9 @@ function pmprogroupacct_pmpro_membership_level_before_content_settings( $level )
 								<option value="recurring" <?php selected( 'recurring', $settings['price_application'] ); ?>><?php esc_html_e( 'Recurring subscription only', 'pmpro-group-accounts' ); ?></option>
 							</select>
 							<p class="description"><?php esc_html_e( 'Define whether the seat cost should be applied for the initial payment, recurring payment, or both.', 'pmpro-group-accounts' ); ?></p>
+							<div id="pmprogroupacct_pricing_model_warning_recurring_billing" style="display: none;" class="pmpro_message pmpro_alert">
+								<p><?php esc_html_e( 'WARNING: This level does not have a recurring subscription. Child accounts will assume a monthly billing period unless you configure the subscription on this parent level.', 'pmpro-group-accounts' ); ?></p>
+							</div>
 						</td>
 					</tr>
 				</tbody>

--- a/includes/parents.php
+++ b/includes/parents.php
@@ -243,12 +243,26 @@ function pmprogroupacct_pmpro_checkout_level_parent( $level ) {
 		case 'both':
 			$level->initial_payment += $seat_cost;
 			$level->billing_amount += $seat_cost;
+			// If the level is not already recurring, default to 1 per Month.
+			if ( empty ( $level->cycle_number ) ) {
+				$level->cycle_number = 1;
+			}
+			if ( empty( $level->cycle_period ) ) {
+				$level->cycle_period = 'Month';
+			}
 			break;
 		case 'initial':
 			$level->initial_payment += $seat_cost;
 			break;
 		case 'recurring':
 			$level->billing_amount += $seat_cost;
+			// If the level is not already recurring, default to 1 per Month.
+			if ( empty ( $level->cycle_number ) ) {
+				$level->cycle_number = 1;
+			}
+			if ( empty( $level->cycle_period ) ) {
+				$level->cycle_period = 'Month';
+			}
 			break;
 	}
 

--- a/js/pmprogroupacct-admin.js
+++ b/js/pmprogroupacct-admin.js
@@ -44,4 +44,43 @@ jQuery( document ).ready( function( $ ) {
 	$( '#pmprogroupacct_pricing_model' ).change( function() {
 		pmprogroupacct_update_edit_level_pricing_model_field_visibility();
 	} );
+
+	// Function to toggle the warning based on the recurring checkbox
+	function pmprogroupacct_toggle_recurring_warning() {
+		var priceApplication = $('#pmprogroupacct_price_application').val();
+		var isRecurringUnchecked = $('#recurring').is(':not(:checked)');
+
+		// Show the warning if price application is 'both' or 'recurring' and the recurring checkbox is unchecked
+		if ( ( priceApplication === 'both' || priceApplication === 'recurring' ) && isRecurringUnchecked ) {
+			$( '#pmprogroupacct_pricing_model_warning_recurring_billing').show();
+		} else {
+			$( '#pmprogroupacct_pricing_model_warning_recurring_billing').hide();
+		}
+	}
+	$( '#recurring, #pmprogroupacct_price_application' ).change(function() {
+		pmprogroupacct_toggle_recurring_warning();
+	});
+
+	// Initial check to set the correct state when the page loads
+	pmprogroupacct_toggle_recurring_warning();
+
+	// Function to toggle the warning based on the level pricing
+	function pmprogroupacct_toggle_free_level_warning() {
+		var priceModel = $('#pmprogroupacct_pricing_model').val();
+		var initialPayment = parseFloat( $( 'input[name="initial_payment"]' ).val() );
+		var isRecurringUnchecked = $('#recurring').is(':not(:checked)');
+
+		// Show the warning if priceModel is 'fixed' and the level is free.
+		if ( priceModel === 'fixed' && initialPayment === 0 && isRecurringUnchecked ) {
+			$( '#pmprogroupacct_pricing_model_warning_free_level').show();
+		} else {
+			$( '#pmprogroupacct_pricing_model_warning_free_level').hide();
+		}
+	}
+	$( 'input[name="initial_payment"], #recurring, #pmprogroupacct_pricing_model' ).change(function() {
+		pmprogroupacct_toggle_free_level_warning();
+	});
+
+	// Initial check to set the correct state when the page loads
+	pmprogroupacct_toggle_free_level_warning();
 } );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-group-accounts/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-group-accounts/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Added warning when recurring is not set on the level and the seats are being billed recurring. The checkout level logic will default to 1 per Month if recurring billing is not seton the level itself.

The admin CAN set $0 initial, $0 recurring and any other custom cycle number and period if they truly do NOT want the parent level to have pricing. checkout will use the stored cycle number and period not fallback to this 1 per month default.

Also showing warnings when level has $0 initial and no recurring that while checkout WILL work, it isn't an idea flow.


![Screenshot 2023-12-02 at 1 59 20 PM](https://github.com/strangerstudios/pmpro-group-accounts/assets/5312875/9c57b9a2-d508-4026-af08-8e7163535ec8)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?
