### PR TITLE
Min and max seats logic

### DIFF
--- a/includes/edit-level.php
+++ b/includes/edit-level.php
@@ -73,7 +73,7 @@ function pmprogroupacct_pmpro_membership_level_before_content_settings( $level )
 							<label for="pmprogroupacct_total_seats"><?php esc_html_e( 'Total Seats', 'pmpro-group-accounts' ); ?></label>
 						</th>
 						<td>
-							<input id="pmprogroupacct_total_seats" name="pmprogroupacct_total_seats" type="number" min="0" value="<?php echo esc_attr( $settings['min_seats'] ); ?>" />
+							<input id="pmprogroupacct_total_seats" name="pmprogroupacct_total_seats" type="number" min="0" max="4294967295" value="<?php echo esc_attr( $settings['min_seats'] ); ?>" />
 							<p class="description"><?php esc_html_e( 'The total number of seats that are included in this group. Note: the group account owner does not count toward this total.', 'pmpro-group-accounts' ); ?></p>
 						</td>
 					</tr>
@@ -82,7 +82,7 @@ function pmprogroupacct_pmpro_membership_level_before_content_settings( $level )
 							<label for="pmprogroupacct_min_seats"><?php esc_html_e( 'Minimum Seats', 'pmpro-group-accounts' ); ?></label>
 						</th>
 						<td>
-							<input id="pmprogroupacct_min_seats" name="pmprogroupacct_min_seats" type="number" min="0" value="<?php echo esc_attr( $settings['min_seats'] ); ?>" />
+							<input id="pmprogroupacct_min_seats" name="pmprogroupacct_min_seats" type="number" min="0" max="4294967295" value="<?php echo esc_attr( $settings['min_seats'] ); ?>" />
 							<p class="description"><?php esc_html_e( 'The minimum number of seats that can be added at checkout.', 'pmpro-group-accounts' ); ?></p>
 						</td>
 					</tr>
@@ -91,7 +91,7 @@ function pmprogroupacct_pmpro_membership_level_before_content_settings( $level )
 							<label for="pmprogroupacct_max_seats"><?php esc_html_e( 'Maximum Seats', 'pmpro-group-accounts' ); ?></label>
 						</th>
 						<td>
-							<input id="pmprogroupacct_max_seats" name="pmprogroupacct_max_seats" type="number" min="0" value="<?php echo esc_attr( $settings['max_seats'] ); ?>" />
+							<input id="pmprogroupacct_max_seats" name="pmprogroupacct_max_seats" type="number" min="0" max="4294967295" value="<?php echo esc_attr( $settings['max_seats'] ); ?>" />
 							<p class="description"><?php esc_html_e( 'The maximum number of seats that can be added at checkout. Note: the group account owner does not count toward this limit.', 'pmpro-group-accounts' ); ?></p>
 						</td>
 					</tr>

--- a/includes/manage-group-page.php
+++ b/includes/manage-group-page.php
@@ -339,7 +339,7 @@ function pmprogroupacct_shortcode_manage_group() {
 					<div class="<?php echo pmpro_get_element_class( 'pmpro_checkout-fields' ); ?>">	
 						<div class="<?php echo pmpro_get_element_class( 'pmpro_checkout-field pmpro_checkout-field-text' ); ?>">
 							<label for="pmprogroupacct_group_total_seats"><?php esc_html_e( 'Total Seats', 'pmpro-group-accounts' ); ?></label>
-							<input type="number" name="pmprogroupacct_group_total_seats" id="pmprogroupacct_group_total_seats" class="<?php echo pmpro_get_element_class( 'input' ); ?>" value="<?php echo esc_attr( $group->group_total_seats ); ?>">
+							<input type="number" max="4294967295" name="pmprogroupacct_group_total_seats" id="pmprogroupacct_group_total_seats" class="<?php echo pmpro_get_element_class( 'input' ); ?>" value="<?php echo esc_attr( $group->group_total_seats ); ?>">
 						</div> <!-- end .pmpro_checkout-field -->
 					</div> <!-- end .pmpro_checkout-fields -->
 					<div class="<?php echo pmpro_get_element_class( 'pmpro_submit' ); ?>">

--- a/js/pmprogroupacct-admin.js
+++ b/js/pmprogroupacct-admin.js
@@ -44,4 +44,14 @@ jQuery( document ).ready( function( $ ) {
 	$( '#pmprogroupacct_pricing_model' ).change( function() {
 		pmprogroupacct_update_edit_level_pricing_model_field_visibility();
 	} );
+
+	// Function to update the min value of max seats based on min seats.
+	function pmprogroupacct_update_max_seats() {
+		var minSeats = $( '#pmprogroupacct_min_seats' ).val();
+		$( '#pmprogroupacct_max_seats' ).attr( 'min', minSeats );
+	}
+	pmprogroupacct_update_max_seats();
+	$('#pmprogroupacct_min_seats').change(function() {
+		pmprogroupacct_update_max_seats();
+	});
 } );


### PR DESCRIPTION

### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-group-accounts/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-group-accounts/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Setting absolute maximum for seats fields. The number “4,294,967,295” is the largest number that can be stored in the database field.

Also added logic to ensure the min seats value is never great than max seats using Javascript. 

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
