### PR TITLE
Fixing activation notice for PMPro not installed; fixing no child accounts to add to group

### DIFF
--- a/includes/edit-level.php
+++ b/includes/edit-level.php
@@ -24,127 +24,154 @@ function pmprogroupacct_pmpro_membership_level_before_content_settings( $level )
 		$settings = array_merge( $settings, $saved_settings );
 	}
 
+	// Get all membership levels.
+	$all_levels = pmpro_getAllLevels( true, true );
+
+	// Remove the current level from the list of levels.
+	unset( $all_levels[ $level->id ] );
+
 	// Build the settings UI.
+	if ( count( $all_levels ) === 0 ) {
+		$section_visibility = 'hidden';
+		$section_activated = 'false';
+	} else {
+		$section_visibility = 'shown';
+		$section_activated = 'true';
+	}
 	?>
-	<div class="pmpro_section" data-visibility="shown" data-activated="true">
+	<div id="pmpro-group-accounts" class="pmpro_section" data-visibility="<?php echo esc_attr( $section_visibility ); ?>" data-activated="<?php echo esc_attr( $section_activated ); ?>">
 		<div class="pmpro_section_toggle">
-			<button class="pmpro_section-toggle-button" type="button" aria-expanded="true">
-				<span class="dashicons dashicons-arrow-up-alt2"></span>
+			<button class="pmpro_section-toggle-button" type="button" aria-expanded="<?php echo $section_visibility === 'hidden' ? 'false' : 'true'; ?>">
+				<span class="dashicons dashicons-arrow-<?php echo $section_visibility === 'hidden' ? 'down' : 'up'; ?>-alt2"></span>
 				<?php esc_html_e( 'Group Account Settings', 'paid-memberships-pro' ); ?>
 			</button>
 		</div>
-		<div class="pmpro_section_inside">
+		<div class="pmpro_section_inside" <?php echo $section_visibility === 'hidden' ? 'style="display: none"' : ''; ?>>
 			<p>
 				<?php esc_html_e( 'Group accounts allow a member to purchase a block of memberships at once. The member will receive a code to distribute to their group for use during registration.', 'pmpro-group-accounts' ); ?>
 				<a href="https://www.paidmembershipspro.com/add-ons/group-accounts?utm_source=plugin&utm_medium=pmpro-membershiplevels&utm_campaign=add-ons&utm_content=view-documentation" target="_blank"><?php esc_html_e( 'View documentation', 'pmpro-group-accounts' ); ?></a>
 			</p>
-			<table class="form-table">
-				<tbody>
-					<tr>
-						<th scope="row" valign="top">
-							<label for="pmprogroupacct_child_level_ids"><?php esc_html_e( 'Membership Level(s)', 'pmpro-group-accounts' ); ?></label>
-						</th>
-						<td>
-							<select id="pmprogroupacct_child_level_ids" name="pmprogroupacct_child_level_ids[]" multiple="multiple">
-								<?php
-								// Get all membership levels except for the one being edited.
-								$all_levels = pmpro_getAllLevels( true, true );
-								unset( $all_levels[ $level->id ] );
-								foreach ( $all_levels as $child_level ) { ?>
-									<option value="<?php echo esc_attr( $child_level->id ); ?>" <?php selected( in_array( $child_level->id, $settings['child_level_ids'] ) ); ?>><?php echo esc_html( $child_level->name ); ?></option>
-								<?php } ?>
-							</select>
-							<p class="description"><?php esc_html_e( 'Select one or more membership levels that can be claimed by group members. Leave blank if this membership level does not offer child accounts.', 'pmpro-group-accounts' ); ?></p>
-					</tr>
-					<tr class="pmprogroupacct_setting">
-						<th scope="row" valign="top">
-							<label for="pmprogroupacct_group_type"><?php esc_html_e( 'Type of Group', 'pmpro-group-accounts' ); ?></label>
-						</th>
-						<td>
-							<select id="pmprogroupacct_group_type" name="pmprogroupacct_group_type">
-								<option value="fixed" <?php selected( $settings['min_seats'] === $settings['max_seats'] ); ?>><?php esc_html_e( 'Fixed - Set a specific number of allowed seats.', 'pmpro-group-accounts' ); ?></option>
-								<option value="variable" <?php selected( $settings['min_seats'] !== $settings['max_seats'] ); ?>><?php esc_html_e( 'Variable - Member can choose number of seats at checkout.', 'pmpro-group-accounts' ); ?></option>
-							</select>
-							<p class="description"><?php esc_html_e( 'Set a specific number of seats in the group or allow the member to choose the number of seats they need at checkout.', 'pmpro-group-accounts' ); ?></p>
-						</td>
-					</tr>
-					<tr class="pmprogroupacct_setting pmprogroupacct_group_type_setting pmprogroupacct_group_type_setting_fixed">
-						<th scope="row" valign="top">
-							<label for="pmprogroupacct_total_seats"><?php esc_html_e( 'Total Seats', 'pmpro-group-accounts' ); ?></label>
-						</th>
-						<td>
-							<input id="pmprogroupacct_total_seats" name="pmprogroupacct_total_seats" type="number" min="0" max="4294967295" value="<?php echo esc_attr( $settings['min_seats'] ); ?>" />
-							<p class="description"><?php esc_html_e( 'The total number of seats that are included in this group. Note: the group account owner does not count toward this total.', 'pmpro-group-accounts' ); ?></p>
-						</td>
-					</tr>
-					<tr class="pmprogroupacct_setting pmprogroupacct_group_type_setting pmprogroupacct_group_type_setting_variable">
-						<th scope="row" valign="top">
-							<label for="pmprogroupacct_min_seats"><?php esc_html_e( 'Minimum Seats', 'pmpro-group-accounts' ); ?></label>
-						</th>
-						<td>
-							<input id="pmprogroupacct_min_seats" name="pmprogroupacct_min_seats" type="number" min="0" max="4294967295" value="<?php echo esc_attr( $settings['min_seats'] ); ?>" />
-							<p class="description"><?php esc_html_e( 'The minimum number of seats that can be added at checkout.', 'pmpro-group-accounts' ); ?></p>
-						</td>
-					</tr>
-					<tr class="pmprogroupacct_setting pmprogroupacct_group_type_setting pmprogroupacct_group_type_setting_variable">
-						<th scope="row" valign="top">
-							<label for="pmprogroupacct_max_seats"><?php esc_html_e( 'Maximum Seats', 'pmpro-group-accounts' ); ?></label>
-						</th>
-						<td>
-							<input id="pmprogroupacct_max_seats" name="pmprogroupacct_max_seats" type="number" min="0" max="4294967295" value="<?php echo esc_attr( $settings['max_seats'] ); ?>" />
-							<p class="description"><?php esc_html_e( 'The maximum number of seats that can be added at checkout. Note: the group account owner does not count toward this limit.', 'pmpro-group-accounts' ); ?></p>
-						</td>
-					</tr>
-					<tr class="pmprogroupacct_setting">
-						<th scope="row" valign="top">
-							<label for="pmprogroupacct_pricing_model"><?php esc_html_e( 'Pricing Model', 'pmpro-group-accounts' ); ?></label>
-						</th>
-						<td>
-							<select id="pmprogroupacct_pricing_model" name="pmprogroupacct_pricing_model">
-								<option value="none" <?php selected( 'none', $settings['pricing_model'] ); ?>><?php esc_html_e( 'None - Group pricing is built into this membership level.', 'pmpro-group-accounts' ); ?></option>
-								<option value="fixed" <?php selected( 'fixed', $settings['pricing_model'] ); ?>><?php esc_html_e( 'Per Seat - Set a specific price per additional seat.', 'pmpro-group-accounts' ); ?></option>
-							</select>
-							<p class="description"><?php esc_html_e( 'The pricing model to use for purchasing seats.', 'pmpro-group-accounts' ); ?></p>
-							<div id="pmprogroupacct_pricing_model_warning_free_level" style="display: none;" class="pmpro_message pmpro_alert">
-								<p><?php esc_html_e( 'WARNING: This level does not have any pricing set up. We highly recommend that you set up an initial payment or recurring billing for a better checkout experience.', 'pmpro-group-accounts' ); ?></p>
-							</div>
-						</td>
-					</tr>
-					<tr class="pmprogroupacct_setting pmprogroupacct_pricing_setting pmprogroupacct_pricing_setting_fixed">
-						<th scope="row" valign="top">
-							<label for="pmprogroupacct_pricing_model_settings"><?php esc_html_e( 'Cost Per Seat', 'pmpro-group-accounts' ); ?></label>
-						</th>
-						<td>
-							<?php
-							if ( pmpro_getCurrencyPosition() == "left" )
-								echo $pmpro_currency_symbol;
-							?>
-							<input name="pmprogroupacct_pricing_model_settings" type="text" value="<?php echo esc_attr( pmpro_filter_price_for_text_field( $settings['pricing_model_settings'] ) ); ?>" class="regular-text" />
-							<?php
-							if ( pmpro_getCurrencyPosition() == "right" )
-								echo $pmpro_currency_symbol;
-							?>
-							<p class="description"><?php esc_html_e( 'The additional cost at checkout per seat.', 'pmpro-group-accounts' ); ?></p>
-						</td>
-					</tr>
-					<tr class="pmprogroupacct_setting pmprogroupacct_pricing_setting pmprogroupacct_pricing_setting_paid">
-						<th scope="row" valign="top">
-							<label for="pmprogroupacct_price_application"><?php esc_html_e( 'Price Application', 'pmpro-group-accounts' ); ?></label>
-						</th>
-						<td>
-							<select id="pmprogroupacct_price_application" name="pmprogroupacct_price_application">
-								<option value="both" <?php selected( 'both', $settings['price_application'] ); ?>><?php esc_html_e( 'Initial payment and recurring subscription', 'pmpro-group-accounts' ); ?></option>
-								<option value="initial" <?php selected( 'initial', $settings['price_application'] ); ?>><?php esc_html_e( 'Initial payment only', 'pmpro-group-accounts' ); ?></option>
-								<option value="recurring" <?php selected( 'recurring', $settings['price_application'] ); ?>><?php esc_html_e( 'Recurring subscription only', 'pmpro-group-accounts' ); ?></option>
-							</select>
-							<p class="description"><?php esc_html_e( 'Define whether the seat cost should be applied for the initial payment, recurring payment, or both.', 'pmpro-group-accounts' ); ?></p>
-							<div id="pmprogroupacct_pricing_model_warning_recurring_billing" style="display: none;" class="pmpro_message pmpro_alert">
-								<p><?php esc_html_e( 'WARNING: This level does not have a recurring subscription. Child accounts will assume a monthly billing period unless you configure the subscription on this parent level.', 'pmpro-group-accounts' ); ?></p>
-							</div>
-						</td>
-					</tr>
-				</tbody>
-			</table>
+			<?php
+				// If there is only one level, show a message and return.
+				if ( count( $all_levels ) === 0 ) {
+					?>
+					<div class="pmpro_message pmpro_alert">
+						<p>
+							<?php esc_html_e( 'You do not have any membership levels that can be set as the child account for this group.', 'pmpro-group-accounts' ); ?>
+							<?php printf( __( 'Please <a target="_blank" href="%s">create an additional membership level</a> to use as the child account for this group.', 'pmpro-group-accounts' ), add_query_arg( array( 'page' => 'pmpro-membershiplevels' ), admin_url( 'admin.php' ) ) ); ?>
+						</p>
+					</div>
+					<?php
+				} else {
+					?>
+					<table class="form-table">
+						<tbody>
+							<tr>
+								<th scope="row" valign="top">
+									<label for="pmprogroupacct_child_level_ids"><?php esc_html_e( 'Membership Level(s)', 'pmpro-group-accounts' ); ?></label>
+								</th>
+								<td>
+									<select id="pmprogroupacct_child_level_ids" name="pmprogroupacct_child_level_ids[]" multiple="multiple">
+										<?php
+										// Show all levels except the current level in the dropdown
+										foreach ( $all_levels as $child_level ) { ?>
+											<option value="<?php echo esc_attr( $child_level->id ); ?>" <?php selected( in_array( $child_level->id, $settings['child_level_ids'] ) ); ?>><?php echo esc_html( $child_level->name ); ?></option>
+										<?php } ?>
+									</select>
+									<p class="description"><?php esc_html_e( 'Select one or more membership levels that can be claimed by group members. Leave blank if this membership level does not offer child accounts.', 'pmpro-group-accounts' ); ?></p>
+							</tr>
+							<tr class="pmprogroupacct_setting">
+								<th scope="row" valign="top">
+									<label for="pmprogroupacct_group_type"><?php esc_html_e( 'Type of Group', 'pmpro-group-accounts' ); ?></label>
+								</th>
+								<td>
+									<select id="pmprogroupacct_group_type" name="pmprogroupacct_group_type">
+										<option value="fixed" <?php selected( $settings['min_seats'] === $settings['max_seats'] ); ?>><?php esc_html_e( 'Fixed - Set a specific number of allowed seats.', 'pmpro-group-accounts' ); ?></option>
+										<option value="variable" <?php selected( $settings['min_seats'] !== $settings['max_seats'] ); ?>><?php esc_html_e( 'Variable - Member can choose number of seats at checkout.', 'pmpro-group-accounts' ); ?></option>
+									</select>
+									<p class="description"><?php esc_html_e( 'Set a specific number of seats in the group or allow the member to choose the number of seats they need at checkout.', 'pmpro-group-accounts' ); ?></p>
+								</td>
+							</tr>
+							<tr class="pmprogroupacct_setting pmprogroupacct_group_type_setting pmprogroupacct_group_type_setting_fixed">
+								<th scope="row" valign="top">
+									<label for="pmprogroupacct_total_seats"><?php esc_html_e( 'Total Seats', 'pmpro-group-accounts' ); ?></label>
+								</th>
+								<td>
+									<input id="pmprogroupacct_total_seats" name="pmprogroupacct_total_seats" type="number" min="0" max="4294967295" value="<?php echo esc_attr( $settings['min_seats'] ); ?>" />
+									<p class="description"><?php esc_html_e( 'The total number of seats that are included in this group. Note: the group account owner does not count toward this total.', 'pmpro-group-accounts' ); ?></p>
+								</td>
+							</tr>
+							<tr class="pmprogroupacct_setting pmprogroupacct_group_type_setting pmprogroupacct_group_type_setting_variable">
+								<th scope="row" valign="top">
+									<label for="pmprogroupacct_min_seats"><?php esc_html_e( 'Minimum Seats', 'pmpro-group-accounts' ); ?></label>
+								</th>
+								<td>
+									<input id="pmprogroupacct_min_seats" name="pmprogroupacct_min_seats" type="number" min="0" max="4294967295" value="<?php echo esc_attr( $settings['min_seats'] ); ?>" />
+									<p class="description"><?php esc_html_e( 'The minimum number of seats that can be added at checkout.', 'pmpro-group-accounts' ); ?></p>
+								</td>
+							</tr>
+							<tr class="pmprogroupacct_setting pmprogroupacct_group_type_setting pmprogroupacct_group_type_setting_variable">
+								<th scope="row" valign="top">
+									<label for="pmprogroupacct_max_seats"><?php esc_html_e( 'Maximum Seats', 'pmpro-group-accounts' ); ?></label>
+								</th>
+								<td>
+									<input id="pmprogroupacct_max_seats" name="pmprogroupacct_max_seats" type="number" min="0" max="4294967295" value="<?php echo esc_attr( $settings['max_seats'] ); ?>" />
+									<p class="description"><?php esc_html_e( 'The maximum number of seats that can be added at checkout. Note: the group account owner does not count toward this limit.', 'pmpro-group-accounts' ); ?></p>
+								</td>
+							</tr>
+							<tr class="pmprogroupacct_setting">
+								<th scope="row" valign="top">
+									<label for="pmprogroupacct_pricing_model"><?php esc_html_e( 'Pricing Model', 'pmpro-group-accounts' ); ?></label>
+								</th>
+								<td>
+									<select id="pmprogroupacct_pricing_model" name="pmprogroupacct_pricing_model">
+										<option value="none" <?php selected( 'none', $settings['pricing_model'] ); ?>><?php esc_html_e( 'None - Group pricing is built into this membership level.', 'pmpro-group-accounts' ); ?></option>
+										<option value="fixed" <?php selected( 'fixed', $settings['pricing_model'] ); ?>><?php esc_html_e( 'Per Seat - Set a specific price per additional seat.', 'pmpro-group-accounts' ); ?></option>
+									</select>
+									<p class="description"><?php esc_html_e( 'The pricing model to use for purchasing seats.', 'pmpro-group-accounts' ); ?></p>
+									<div id="pmprogroupacct_pricing_model_warning_free_level" style="display: none;" class="pmpro_message pmpro_alert">
+										<p><?php esc_html_e( 'WARNING: This level does not have any pricing set up. We highly recommend that you set up an initial payment or recurring billing for a better checkout experience.', 'pmpro-group-accounts' ); ?></p>
+									</div>
+								</td>
+							</tr>
+							<tr class="pmprogroupacct_setting pmprogroupacct_pricing_setting pmprogroupacct_pricing_setting_fixed">
+								<th scope="row" valign="top">
+									<label for="pmprogroupacct_pricing_model_settings"><?php esc_html_e( 'Cost Per Seat', 'pmpro-group-accounts' ); ?></label>
+								</th>
+								<td>
+									<?php
+									if ( pmpro_getCurrencyPosition() == "left" )
+										echo $pmpro_currency_symbol;
+									?>
+									<input name="pmprogroupacct_pricing_model_settings" type="text" value="<?php echo esc_attr( pmpro_filter_price_for_text_field( $settings['pricing_model_settings'] ) ); ?>" class="regular-text" />
+									<?php
+									if ( pmpro_getCurrencyPosition() == "right" )
+										echo $pmpro_currency_symbol;
+									?>
+									<p class="description"><?php esc_html_e( 'The additional cost at checkout per seat.', 'pmpro-group-accounts' ); ?></p>
+								</td>
+							</tr>
+							<tr class="pmprogroupacct_setting pmprogroupacct_pricing_setting pmprogroupacct_pricing_setting_paid">
+								<th scope="row" valign="top">
+									<label for="pmprogroupacct_price_application"><?php esc_html_e( 'Price Application', 'pmpro-group-accounts' ); ?></label>
+								</th>
+								<td>
+									<select id="pmprogroupacct_price_application" name="pmprogroupacct_price_application">
+										<option value="both" <?php selected( 'both', $settings['price_application'] ); ?>><?php esc_html_e( 'Initial payment and recurring subscription', 'pmpro-group-accounts' ); ?></option>
+										<option value="initial" <?php selected( 'initial', $settings['price_application'] ); ?>><?php esc_html_e( 'Initial payment only', 'pmpro-group-accounts' ); ?></option>
+										<option value="recurring" <?php selected( 'recurring', $settings['price_application'] ); ?>><?php esc_html_e( 'Recurring subscription only', 'pmpro-group-accounts' ); ?></option>
+									</select>
+									<p class="description"><?php esc_html_e( 'Define whether the seat cost should be applied for the initial payment, recurring payment, or both.', 'pmpro-group-accounts' ); ?></p>
+									<div id="pmprogroupacct_pricing_model_warning_recurring_billing" style="display: none;" class="pmpro_message pmpro_alert">
+										<p><?php esc_html_e( 'WARNING: This level does not have a recurring subscription. Child accounts will assume a monthly billing period unless you configure the subscription on this parent level.', 'pmpro-group-accounts' ); ?></p>
+									</div>
+								</td>
+							</tr>
+						</tbody>
+					</table>
+					<?php
+				}
+			?>
 		</div> <!-- end .pmpro_section_inside -->
 	</div> <!-- end .pmpro_section -->
 	<?php

--- a/includes/edit-user.php
+++ b/includes/edit-user.php
@@ -28,8 +28,7 @@ function pmprogroupacct_after_membership_level_profile_fields( $user ) {
 
 	// Show the UI.
 	?>
-	<hr>
-	<h2><?php esc_html_e( 'PMPro Group Accounts Add On', 'pmpro-group-accounts' ); ?></h2>
+	<h2><?php esc_html_e( 'Group Accounts', 'pmpro-group-accounts' ); ?></h2>
 	<h3><?php esc_html_e( 'Manage Groups', 'pmpro-group-accounts' ); ?></h3>
 	<?php
 	if ( empty( $groups ) ) {

--- a/includes/scripts.php
+++ b/includes/scripts.php
@@ -5,12 +5,12 @@
  * @since 1.0
  */
 function pmprogroupacct_admin_enqueue_scripts() {
-    // Enqueue the admin script.
-    wp_enqueue_script( 'pmprogroupacct-admin', plugins_url( 'js/pmprogroupacct-admin.js', dirname(__FILE__) ), array( 'jquery' ), PMPROGROUPACCT_VERSION );
+	// Enqueue the admin script.
+	wp_enqueue_script( 'pmprogroupacct-admin', plugins_url( 'js/pmprogroupacct-admin.js', dirname(__FILE__) ), array( 'jquery' ), PMPROGROUPACCT_VERSION );
 
-    // Enqueue select2 JS and CSS.
-    wp_enqueue_script( 'select2', plugins_url( 'js/select2.min.js', dirname(__FILE__) ), array( 'jquery' ), '4.0.13' );
-    wp_enqueue_style( 'select2', plugins_url( 'css/select2.min.css', dirname(__FILE__) ), array(), '4.0.13' );
+	// Enqueue select2 JS and CSS.
+	wp_enqueue_script( 'select2', plugins_url( 'js/select2.min.js', dirname(__FILE__) ), array( 'jquery' ), '4.0.13' );
+	wp_enqueue_style( 'select2', plugins_url( 'css/select2.min.css', dirname(__FILE__) ), array(), '4.0.13' );
 }
 add_action( 'admin_enqueue_scripts', 'pmprogroupacct_admin_enqueue_scripts' );
 
@@ -20,7 +20,7 @@ add_action( 'admin_enqueue_scripts', 'pmprogroupacct_admin_enqueue_scripts' );
  * @since 1.0
  */
 function pmprogroupacct_wp_enqueue_scripts() {
-    // Enqueue the checkout script.
-    wp_enqueue_script( 'pmprogroupacct-checkout', plugins_url( 'js/pmprogroupacct-checkout.js', dirname(__FILE__) ), array( 'jquery' ), PMPROGROUPACCT_VERSION );
+	// Enqueue the checkout script.
+	wp_enqueue_script( 'pmprogroupacct-checkout', plugins_url( 'js/pmprogroupacct-checkout.js', dirname(__FILE__) ), array( 'jquery' ), PMPROGROUPACCT_VERSION );
 }
 add_action( 'wp_enqueue_scripts', 'pmprogroupacct_wp_enqueue_scripts' );

--- a/readme.txt
+++ b/readme.txt
@@ -28,5 +28,5 @@ View full documentation at: https://www.paidmembershipspro.com/add-ons/group-acc
 
 == Changelog ==
 
-= 1.0 - 2023-12-05 =
+= 1.0 - 2023-12-06 =
 * Initial release.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-group-accounts/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-group-accounts/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Fixing case where Group Accounts is activated but Paid Memberships Pro is not active (activation notice)

Fixing case where there is no membership level (adding first one) or only 1 level exists because you cannot add the parent group as a child of the group.

