### PR TITLE
Double check that code can claim level at chekcout

### DIFF
--- a/classes/class-pmprogroupacct-group.php
+++ b/classes/class-pmprogroupacct-group.php
@@ -393,4 +393,20 @@ class PMProGroupAcct_Group {
 
 		return $new_group_checkout_code;
 	}
+
+	/**
+	 * Checks whether a specific level ID can be claimed by joining this group.
+	 *
+	 * @since TBD
+	 *
+	 * @param int $level_id The ID of the membership level to check.
+	 * @return bool True if the level can be claimed by joining this group, false otherwise.
+	 */
+	public function can_claim_level( $level_id ) {
+		$settings = pmprogroupacct_get_settings_for_level( $this->group_parent_level_id );
+		if ( empty( $settings ) ) {
+			return false;
+		}
+		return in_array( (int)$level_id, $settings['child_level_ids'], true );
+	}
 }

--- a/includes/children.php
+++ b/includes/children.php
@@ -22,9 +22,12 @@ function pmprogroupacct_checkout_before_form_child() {
 	if ( ! empty( $group_code ) ) {
 		// Check if the group code is valid.
 		$group = PMProGroupAcct_Group::get_group_by_checkout_code( $group_code );
-		if ( ! empty( $group ) && $group->is_accepting_signups() ) {
+		if ( ! empty( $group ) && $group->is_accepting_signups() && $group->can_claim_level( $checkout_level->id ) ) {
 			// Show a message that the group code has been applied.
 			pmpro_setMessage( esc_html__( 'Group code applied.', 'pmpro-group-accounts' ), 'pmpro_success' );
+		} elseif ( ! $group->can_claim_level( $checkout_level->id ) ) {
+			// Show a message that the group code cannot be used to claim this level.
+			pmpro_setMessage( esc_html__( 'This group code cannot be used to claim this level.', 'pmpro-group-accounts' ), 'pmpro_error' );
 		} elseif ( ! empty( $group ) ) {
 			// Show a message that the group code is not accepting signups.
 			pmpro_setMessage( esc_html__( 'This group is no longer accepting signups.', 'pmpro-group-accounts' ), 'pmpro_error' );
@@ -60,7 +63,7 @@ function pmprogroupacct_checkout_after_level_cost_child() {
 	if ( ! empty( $group_code ) ) {
 		// Check if the group code is valid.
 		$group = PMProGroupAcct_Group::get_group_by_checkout_code( $group_code );
-		if ( ! empty( $group ) && $group->is_accepting_signups() ) {
+		if ( ! empty( $group ) && $group->is_accepting_signups() && $group->can_claim_level( $checkout_level->id ) ) {
 			// Add a hidden field to the checkout form with the group code and return so that we don't show the group code field.
 			?>
 			<p>
@@ -121,7 +124,7 @@ function pmprogroupacct_pmpro_checkout_level_child( $level ) {
 	if ( ! empty( $group_code ) ) {
 		// Check if the group code is valid.
 		$group = PMProGroupAcct_Group::get_group_by_checkout_code( $group_code );
-		if ( ! empty( $group ) && $group->is_accepting_signups() ) {
+		if ( ! empty( $group ) && $group->is_accepting_signups() && $group->can_claim_level( $level->id ) ) {
 			// Set the level cost to 0.
 			$level->initial_payment = 0;
 			$level->billing_amount  = 0;
@@ -155,7 +158,7 @@ function pmprogroupacct_pmpro_level_cost_text_child_checkout( $level_cost_text, 
 	if ( ! empty( $group_code ) ) {
 		// Check if the group code is valid.
 		$group = PMProGroupAcct_Group::get_group_by_checkout_code( $group_code );
-		if ( ! empty( $group ) && $group->is_accepting_signups() ) {
+		if ( ! empty( $group ) && $group->is_accepting_signups() && $group->can_claim_level( $level->id ) ) {
 			// Unset the level cost text.
 			$level_cost_text = '';
 		}
@@ -203,6 +206,13 @@ function pmprogroupacct_pmpro_registration_checks_child( $pmpro_continue_registr
 	if ( empty( $group ) ) {
 		// This is not a valid group code. Show an error message.
 		pmpro_setMessage( esc_html__( 'Invalid group code.', 'pmpro-group-accounts' ), 'pmpro_error' );
+		return false;
+	}
+
+	// Make sure that the group code can claim the level being checked out for.
+	if ( ! $group->can_claim_level( $checkout_level->id ) ) {
+		// This group code cannot claim this level. Show an error message.
+		pmpro_setMessage( esc_html__( 'This group code cannot be used to claim this level.', 'pmpro-group-accounts' ), 'pmpro_error' );
 		return false;
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-group-accounts/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-group-accounts/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Resolves #22 

Fixes issue where group codes could claim levels other than the ones specified for the corresponding parent level.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
