### PR TITLE
Showing cc fields at checkout when paid seats are required

### DIFF
--- a/includes/parents.php
+++ b/includes/parents.php
@@ -211,8 +211,8 @@ function pmprogroupacct_pmpro_checkout_level_parent( $level ) {
 		return $level;
 	}
 
-	// Get the number of seats being purchased.
-	$seats = isset( $_REQUEST['pmprogroupacct_seats'] ) ? intval( $_REQUEST['pmprogroupacct_seats'] ) : 0;
+	// Get the number of seats being purchased. This is either the number of seats entered or the minimum seats if set.
+	$seats = intval( isset( $_REQUEST['pmprogroupacct_seats'] ) ? $_REQUEST['pmprogroupacct_seats'] : $settings['min_seats'] );
 
 	// If the number of seats is not an integer, bail.
 	if ( empty( $seats ) || ! is_numeric( $seats ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-group-accounts/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-group-accounts/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### How to test the changes in this Pull Request:

1. Create parent level with no initial payment, no recurring payment, but paid seats with a non-zero seat minimum
2. View checkout for the level. See that CC fields do not show before this fix, but do show afterwards.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
