### PR TITLE
Add 'pmpro_alter_price' class to the number of seats field

### DIFF
--- a/includes/parents.php
+++ b/includes/parents.php
@@ -77,7 +77,7 @@ function pmprogroupacct_pmpro_checkout_boxes_parent() {
 				?>
 				<div class="pmpro_checkout-field pmpro_checkout-field-seats">
 					<label for="pmprogroupacct_seats"><?php esc_html_e( 'Number of Seats', 'pmpro-group-accounts' ); ?></label>
-					<input id="pmprogroupacct_seats" name="pmprogroupacct_seats" type="number" min="<?php echo esc_attr( $settings['min_seats'] ); ?>" max="<?php echo esc_attr( $settings['max_seats'] ); ?>" value="<?php echo esc_attr( $settings['min_seats'] ); ?>" />
+					<input class="<?php echo esc_attr( pmpro_get_element_class( 'input pmpro_alter_price' ) ); ?>" id="pmprogroupacct_seats" name="pmprogroupacct_seats" type="number" min="<?php echo esc_attr( $settings['min_seats'] ); ?>" max="<?php echo esc_attr( $settings['max_seats'] ); ?>" value="<?php echo esc_attr( $settings['min_seats'] ); ?>" />
 					<p class="description"><?php printf( esc_html__( 'Choose the number of seats to purchase. You can purchase between %s and %s seats.', 'pmpro-group-accounts' ), esc_html( number_format_i18n( ( (int)$settings['min_seats'] ) ) ), esc_html( number_format_i18n( (int)$settings['max_seats'] ) ) ); ?></p>
 				</div> <!-- end .pmpro_checkout-field-seats -->
 				<?php


### PR DESCRIPTION
The "Number of seats" field can alter the checkout price. Adding the "pmpro_alter_price" class to the field

![image](https://github.com/strangerstudios/pmpro-group-accounts/assets/123358258/6cfc4e99-0296-4263-95ca-52f9f7c42282)


### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-group-accounts/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-group-accounts/pulls/) for the same update/change?