### PR TITLE
Change price application default

### DIFF
--- a/includes/edit-level.php
+++ b/includes/edit-level.php
@@ -15,7 +15,7 @@ function pmprogroupacct_pmpro_membership_level_before_content_settings( $level )
 		'max_seats'				 => 0,
 		'pricing_model'			 => 'none', // none, fixed
 		'pricing_model_settings' => 0,
-		'price_application'		 => 'both', // initial, recurring, both
+		'price_application'		 => 'initial', // initial, recurring, both
 	);
 
 	// Get the group account settings for the level.
@@ -157,8 +157,8 @@ function pmprogroupacct_pmpro_membership_level_before_content_settings( $level )
 								</th>
 								<td>
 									<select id="pmprogroupacct_price_application" name="pmprogroupacct_price_application">
-										<option value="both" <?php selected( 'both', $settings['price_application'] ); ?>><?php esc_html_e( 'Initial payment and recurring subscription', 'pmpro-group-accounts' ); ?></option>
 										<option value="initial" <?php selected( 'initial', $settings['price_application'] ); ?>><?php esc_html_e( 'Initial payment only', 'pmpro-group-accounts' ); ?></option>
+										<option value="both" <?php selected( 'both', $settings['price_application'] ); ?>><?php esc_html_e( 'Initial payment and recurring subscription', 'pmpro-group-accounts' ); ?></option>
 										<option value="recurring" <?php selected( 'recurring', $settings['price_application'] ); ?>><?php esc_html_e( 'Recurring subscription only', 'pmpro-group-accounts' ); ?></option>
 									</select>
 									<p class="description"><?php esc_html_e( 'Define whether the seat cost should be applied for the initial payment, recurring payment, or both.', 'pmpro-group-accounts' ); ?></p>

--- a/includes/edit-level.php
+++ b/includes/edit-level.php
@@ -158,8 +158,8 @@ function pmprogroupacct_pmpro_membership_level_before_content_settings( $level )
 								<td>
 									<select id="pmprogroupacct_price_application" name="pmprogroupacct_price_application">
 										<option value="initial" <?php selected( 'initial', $settings['price_application'] ); ?>><?php esc_html_e( 'Initial payment only', 'pmpro-group-accounts' ); ?></option>
-										<option value="both" <?php selected( 'both', $settings['price_application'] ); ?>><?php esc_html_e( 'Initial payment and recurring subscription', 'pmpro-group-accounts' ); ?></option>
 										<option value="recurring" <?php selected( 'recurring', $settings['price_application'] ); ?>><?php esc_html_e( 'Recurring subscription only', 'pmpro-group-accounts' ); ?></option>
+										<option value="both" <?php selected( 'both', $settings['price_application'] ); ?>><?php esc_html_e( 'Initial payment and recurring subscription', 'pmpro-group-accounts' ); ?></option>
 									</select>
 									<p class="description"><?php esc_html_e( 'Define whether the seat cost should be applied for the initial payment, recurring payment, or both.', 'pmpro-group-accounts' ); ?></p>
 									<div id="pmprogroupacct_pricing_model_warning_recurring_billing" style="display: none;" class="pmpro_message pmpro_alert">


### PR DESCRIPTION
* BUG FIX/ENHANCEMENT: Change the price_application default to `initial`. This fixes a bug with PayFast causing recurring subscriptions to be created even when the price_application wasn't set. This is gateway specific logic that was out of our control.

* REFACTOR: Change the dropdown order of the price_application to be initial, recurring and both (in that order)
