### PR TITLE
Fix fatal error if PMPro is disabled

### DIFF
--- a/includes/manage-group-page.php
+++ b/includes/manage-group-page.php
@@ -107,6 +107,11 @@ add_action( 'wp', 'pmprogroupacct_manage_group_preheader', 1 );
  * @return string $content Content for the shortcode.
  */
 function pmprogroupacct_shortcode_manage_group() {
+	// Make sure that PMPro is enabled.
+	if ( ! function_exists( 'pmpro_get_element_class' ) ) {
+		return '<p>' . esc_html__( 'Paid Memberships Pro must be enabled to use the Group Accounts Add On.', 'pmpro-group-accounts' ) . '</p>';
+	}
+
 	// Make sure that a group was passed. If not, show an error.
 	if ( empty( $_REQUEST['pmprogroupacct_group_id'] ) ) {
 		return '<p>' . esc_html__( 'No group was passed.', 'pmpro-group-accounts' ) . '</p>';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-group-accounts/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-group-accounts/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Fixes a fatal error when viewing the Manage Group page if PMPro is disabled.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
