### PR TITLE
Copy group account settings when a level is copied

### DIFF
--- a/includes/edit-level.php
+++ b/includes/edit-level.php
@@ -18,8 +18,20 @@ function pmprogroupacct_pmpro_membership_level_before_content_settings( $level )
 		'price_application'		 => 'initial', // initial, recurring, both
 	);
 
+	// Are we copying a level?
+	if ( isset( $_REQUEST['copy'] ) ) {
+		$copy = intval( $_REQUEST['copy'] );
+	}
+
 	// Get the group account settings for the level.
-	$saved_settings = pmprogroupacct_get_settings_for_level( $level->id );
+	if ( ! empty( $copy ) && $copy > 0 ) {
+		// If we're copying, get the group account settings from the copied level.
+		$saved_settings = pmprogroupacct_get_settings_for_level( $copy );
+	} else {
+		// Get the group account settings for the level being edited
+		$saved_settings = pmprogroupacct_get_settings_for_level( $level->id );
+	}
+
 	if ( ! empty( $saved_settings ) ) {
 		$settings = array_merge( $settings, $saved_settings );
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-group-accounts/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-group-accounts/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Copy group account settings when a level is copied

Resolves #36

### How to test the changes in this Pull Request:

1. Create a level with group account settings.
2. Copy the level.
3. Check the Group Account Settings section on the _copy_ level.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
