### PR TITLE
Fix warnings when level or user deleted

### DIFF
--- a/includes/emails.php
+++ b/includes/emails.php
@@ -101,18 +101,20 @@ function pmprogroupacct_email_data( $data, $email ) {
 		<?php
 		foreach ( $child_level_ids as $child_level_id ) {
 			$child_level = pmpro_getLevel( $child_level_id );
-			?>
-			<li>
-				<?php
-					/* translators: 1: membership level name, 2: membership level checkout link */
-					printf(
-						esc_html__( '%1$s membership: %2$s', 'pmpro-group-accounts' ),
-						esc_html( $child_level->name ),
-						esc_url( add_query_arg( array( 'level' => $child_level->id, 'pmprogroupacct_group_code' => $group->group_checkout_code ), pmpro_url( 'checkout' ) ) )
-					);
+			if ( ! empty( $child_level ) ) {
 				?>
-			</li>
-			<?php
+				<li>
+					<?php
+						/* translators: 1: membership level name, 2: membership level checkout link */
+						printf(
+							esc_html__( '%1$s membership: %2$s', 'pmpro-group-accounts' ),
+							esc_html( $child_level->name ),
+							esc_url( add_query_arg( array( 'level' => $child_level->id, 'pmprogroupacct_group_code' => $group->group_checkout_code ), pmpro_url( 'checkout' ) ) )
+						);
+					?>
+				</li>
+				<?php
+			}
 		}
 		?>
 	</ul>

--- a/includes/emails.php
+++ b/includes/emails.php
@@ -101,20 +101,21 @@ function pmprogroupacct_email_data( $data, $email ) {
 		<?php
 		foreach ( $child_level_ids as $child_level_id ) {
 			$child_level = pmpro_getLevel( $child_level_id );
-			if ( ! empty( $child_level ) ) {
-				?>
-				<li>
-					<?php
-						/* translators: 1: membership level name, 2: membership level checkout link */
-						printf(
-							esc_html__( '%1$s membership: %2$s', 'pmpro-group-accounts' ),
-							esc_html( $child_level->name ),
-							esc_url( add_query_arg( array( 'level' => $child_level->id, 'pmprogroupacct_group_code' => $group->group_checkout_code ), pmpro_url( 'checkout' ) ) )
-						);
-					?>
-				</li>
-				<?php
+			if ( empty( $child_level ) ) {
+				continue;
 			}
+			?>
+			<li>
+				<?php
+					/* translators: 1: membership level name, 2: membership level checkout link */
+					printf(
+						esc_html__( '%1$s membership: %2$s', 'pmpro-group-accounts' ),
+						esc_html( $child_level->name ),
+						esc_url( add_query_arg( array( 'level' => $child_level->id, 'pmprogroupacct_group_code' => $group->group_checkout_code ), pmpro_url( 'checkout' ) ) )
+					);
+				?>
+			</li>
+			<?php
 		}
 		?>
 	</ul>

--- a/includes/manage-group-page.php
+++ b/includes/manage-group-page.php
@@ -479,7 +479,9 @@ function pmprogroupacct_shortcode_manage_group() {
 										$level = pmpro_getLevel( $member->group_child_level_id );
 										?>
 										<tr>
-											<th data-title="<?php esc_attr_e( 'Username', 'pmpro-group-accounts' ); ?>"><?php echo esc_html( $user->user_login ); ?></th>
+											<th data-title="<?php esc_attr_e( 'Username', 'pmpro-group-accounts' ); ?>">
+												<?php echo ! empty( $user ) ? esc_html( $user->user_login ) : esc_html__( '[deleted]', 'pmpro-group-accounts' ); ?>
+											</th>
 											<td data-title="<?php esc_attr_e( 'Level', 'pmpro-group-accounts' ); ?>"><?php echo esc_html( $level->name ); ?></td>
 											<td data-title="<?php esc_attr_e( 'Remove', 'pmpro-group-accounts' ); ?>"><input type="checkbox" name="pmprogroupacct_remove_group_members[]" class="<?php echo pmpro_get_element_class( 'input' ); ?>" value="<?php echo esc_attr( $member->id ); ?>"></td>
 										</tr>
@@ -519,17 +521,19 @@ function pmprogroupacct_shortcode_manage_group() {
 								<?php
 								foreach ( $group_settings['child_level_ids'] as $child_level_id ) {
 									$child_level = pmpro_getLevel( $child_level_id );
-									$checkout_url = add_query_arg( array( 'level' => $child_level->id, 'pmprogroupacct_group_code' => $group->group_checkout_code ), pmpro_url( 'checkout' ) );
-									?>
-									<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-textarea' ) ); ?>">
-										<label for="pmprogroupaccount_link-level-<?php echo esc_attr( $child_level_id ); ?>" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label', 'pmprogroupaccount_link-level-' . esc_attr( $child_level_id ) ) ); ?>">
-											<a href="<?php echo esc_url( $checkout_url ); ?>">
-												<?php printf( esc_html__( 'For %s membership:', 'pmpro-group-accounts' ), esc_html( $child_level->name ) ); ?>
-											</a>
-										</label>
-										<textarea id="pmprogroupaccount_link-level-<?php echo esc_attr( $child_level_id ); ?>" readonly class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-textarea', 'pmpro_form_input-textarea' ) ); ?>" rows="2"><?php echo esc_attr( $checkout_url ); ?></textarea>
-									</div>
-									<?php
+									if ( ! empty( $child_level ) ) {
+										$checkout_url = add_query_arg( array( 'level' => $child_level->id, 'pmprogroupacct_group_code' => $group->group_checkout_code ), pmpro_url( 'checkout' ) );
+										?>
+										<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-textarea' ) ); ?>">
+											<label for="pmprogroupaccount_link-level-<?php echo esc_attr( $child_level_id ); ?>" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label', 'pmprogroupaccount_link-level-' . esc_attr( $child_level_id ) ) ); ?>">
+												<a href="<?php echo esc_url( $checkout_url ); ?>">
+													<?php printf( esc_html__( 'For %s membership:', 'pmpro-group-accounts' ), esc_html( $child_level->name ) ); ?>
+												</a>
+											</label>
+											<textarea id="pmprogroupaccount_link-level-<?php echo esc_attr( $child_level_id ); ?>" readonly class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-textarea', 'pmpro_form_input-textarea' ) ); ?>" rows="2"><?php echo esc_attr( $checkout_url ); ?></textarea>
+										</div>
+										<?php
+									}
 								}
 								?>
 							</div> <!-- end .pmpro_form_fields -->
@@ -587,9 +591,11 @@ function pmprogroupacct_shortcode_manage_group() {
 														<?php
 														foreach ( $group_settings['child_level_ids'] as $child_level_id ) {
 															$child_level = pmpro_getLevel( $child_level_id );
-															?>
-															<option value="<?php echo esc_attr( $child_level->id ); ?>"><?php echo esc_html( $child_level->name ); ?></option>
-															<?php
+															if ( ! empty( $child_level ) ) {
+																?>
+																<option value="<?php echo esc_attr( $child_level->id ); ?>"><?php echo esc_html( $child_level->name ); ?></option>
+																<?php
+															}
 														}
 														?>
 													</select>
@@ -650,9 +656,11 @@ function pmprogroupacct_shortcode_manage_group() {
 														<?php
 														foreach ( $group_settings['child_level_ids'] as $child_level_id ) {
 															$child_level = pmpro_getLevel( $child_level_id );
-															?>
-															<option value="<?php echo esc_attr( $child_level->id ); ?>"><?php echo esc_html( $child_level->name ); ?></option>
-															<?php
+															if ( ! empty( $child_level ) ) {
+																?>
+																<option value="<?php echo esc_attr( $child_level->id ); ?>"><?php echo esc_html( $child_level->name ); ?></option>
+																<?php
+															}
 														}
 														?>
 													</select>
@@ -692,13 +700,15 @@ function pmprogroupacct_shortcode_manage_group() {
 								<?php
 								foreach ( $old_members as $member ) {
 									$user  = get_userdata( $member->group_child_user_id );
-									$level = pmpro_getLevel( $member->group_child_level_id );
-									?>
-									<tr>
-										<td><?php echo esc_html( $user->user_login ); ?></td>
-										<td><?php echo esc_html( $level->name ); ?></td>
-									</tr>
-									<?php
+									if ( ! empty( $user ) ) {
+										$level = pmpro_getLevel( $member->group_child_level_id );
+										?>
+										<tr>
+											<td><?php echo esc_html( $user->user_login ); ?></td>
+											<td><?php echo ! empty( $level ) ? esc_html( $level->name ) : esc_html__( '[deleted]', 'pmpro-group-accounts' ); ?></td>
+										</tr>
+										<?php
+									}
 								}
 								?>
 							</tbody>

--- a/includes/manage-group-page.php
+++ b/includes/manage-group-page.php
@@ -476,12 +476,16 @@ function pmprogroupacct_shortcode_manage_group() {
 									<?php
 									foreach ( $active_members as $member ) {
 										$user  = get_userdata( $member->group_child_user_id );
+										if ( ! empty( $user ) ) {
+											$username = esc_html( $user->user_login );
+										} else {
+											$username = esc_html__( '[deleted]', 'pmpro-group-accounts' );
+										}
+
 										$level = pmpro_getLevel( $member->group_child_level_id );
 										?>
 										<tr>
-											<th data-title="<?php esc_attr_e( 'Username', 'pmpro-group-accounts' ); ?>">
-												<?php echo ! empty( $user ) ? esc_html( $user->user_login ) : esc_html__( '[deleted]', 'pmpro-group-accounts' ); ?>
-											</th>
+											<th data-title="<?php esc_attr_e( 'Username', 'pmpro-group-accounts' ); ?>"><?php echo $username; ?></th>
 											<td data-title="<?php esc_attr_e( 'Level', 'pmpro-group-accounts' ); ?>"><?php echo esc_html( $level->name ); ?></td>
 											<td data-title="<?php esc_attr_e( 'Remove', 'pmpro-group-accounts' ); ?>"><input type="checkbox" name="pmprogroupacct_remove_group_members[]" class="<?php echo pmpro_get_element_class( 'input' ); ?>" value="<?php echo esc_attr( $member->id ); ?>"></td>
 										</tr>
@@ -521,19 +525,21 @@ function pmprogroupacct_shortcode_manage_group() {
 								<?php
 								foreach ( $group_settings['child_level_ids'] as $child_level_id ) {
 									$child_level = pmpro_getLevel( $child_level_id );
-									if ( ! empty( $child_level ) ) {
-										$checkout_url = add_query_arg( array( 'level' => $child_level->id, 'pmprogroupacct_group_code' => $group->group_checkout_code ), pmpro_url( 'checkout' ) );
-										?>
-										<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-textarea' ) ); ?>">
-											<label for="pmprogroupaccount_link-level-<?php echo esc_attr( $child_level_id ); ?>" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label', 'pmprogroupaccount_link-level-' . esc_attr( $child_level_id ) ) ); ?>">
-												<a href="<?php echo esc_url( $checkout_url ); ?>">
-													<?php printf( esc_html__( 'For %s membership:', 'pmpro-group-accounts' ), esc_html( $child_level->name ) ); ?>
-												</a>
-											</label>
-											<textarea id="pmprogroupaccount_link-level-<?php echo esc_attr( $child_level_id ); ?>" readonly class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-textarea', 'pmpro_form_input-textarea' ) ); ?>" rows="2"><?php echo esc_attr( $checkout_url ); ?></textarea>
-										</div>
-										<?php
+									if ( empty( $child_level ) ) {
+										continue;
 									}
+
+									$checkout_url = add_query_arg( array( 'level' => $child_level->id, 'pmprogroupacct_group_code' => $group->group_checkout_code ), pmpro_url( 'checkout' ) );
+									?>
+									<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-textarea' ) ); ?>">
+										<label for="pmprogroupaccount_link-level-<?php echo esc_attr( $child_level_id ); ?>" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label', 'pmprogroupaccount_link-level-' . esc_attr( $child_level_id ) ) ); ?>">
+											<a href="<?php echo esc_url( $checkout_url ); ?>">
+												<?php printf( esc_html__( 'For %s membership:', 'pmpro-group-accounts' ), esc_html( $child_level->name ) ); ?>
+											</a>
+										</label>
+										<textarea id="pmprogroupaccount_link-level-<?php echo esc_attr( $child_level_id ); ?>" readonly class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-textarea', 'pmpro_form_input-textarea' ) ); ?>" rows="2"><?php echo esc_attr( $checkout_url ); ?></textarea>
+									</div>
+									<?php
 								}
 								?>
 							</div> <!-- end .pmpro_form_fields -->
@@ -591,11 +597,12 @@ function pmprogroupacct_shortcode_manage_group() {
 														<?php
 														foreach ( $group_settings['child_level_ids'] as $child_level_id ) {
 															$child_level = pmpro_getLevel( $child_level_id );
-															if ( ! empty( $child_level ) ) {
-																?>
-																<option value="<?php echo esc_attr( $child_level->id ); ?>"><?php echo esc_html( $child_level->name ); ?></option>
-																<?php
+															if ( empty( $child_level ) ) {
+																continue;
 															}
+															?>
+															<option value="<?php echo esc_attr( $child_level->id ); ?>"><?php echo esc_html( $child_level->name ); ?></option>
+															<?php
 														}
 														?>
 													</select>
@@ -656,11 +663,12 @@ function pmprogroupacct_shortcode_manage_group() {
 														<?php
 														foreach ( $group_settings['child_level_ids'] as $child_level_id ) {
 															$child_level = pmpro_getLevel( $child_level_id );
-															if ( ! empty( $child_level ) ) {
-																?>
-																<option value="<?php echo esc_attr( $child_level->id ); ?>"><?php echo esc_html( $child_level->name ); ?></option>
-																<?php
+															if ( empty( $child_level ) ) {
+																continue;
 															}
+															?>
+															<option value="<?php echo esc_attr( $child_level->id ); ?>"><?php echo esc_html( $child_level->name ); ?></option>
+															<?php
 														}
 														?>
 													</select>
@@ -699,16 +707,23 @@ function pmprogroupacct_shortcode_manage_group() {
 							<tbody>
 								<?php
 								foreach ( $old_members as $member ) {
-									$user  = get_userdata( $member->group_child_user_id );
-									if ( ! empty( $user ) ) {
-										$level = pmpro_getLevel( $member->group_child_level_id );
-										?>
-										<tr>
-											<td><?php echo esc_html( $user->user_login ); ?></td>
-											<td><?php echo ! empty( $level ) ? esc_html( $level->name ) : esc_html__( '[deleted]', 'pmpro-group-accounts' ); ?></td>
-										</tr>
-										<?php
+									$user = get_userdata( $member->group_child_user_id );
+									if ( empty ( $user ) ) {
+										continue;
 									}
+
+									$level = pmpro_getLevel( $member->group_child_level_id );
+									if ( ! empty( $level ) ) {
+										$level_name = $level->name;
+									} else {
+										$level_name = esc_html__( '[deleted]', 'pmpro-group-accounts' );
+									}
+									?>
+									<tr>
+										<td><?php echo esc_html( $user->user_login ); ?></td>
+										<td><?php echo esc_html( $level_name ); ?></td>
+									</tr>
+									<?php
 								}
 								?>
 							</tbody>

--- a/includes/manage-group-page.php
+++ b/includes/manage-group-page.php
@@ -477,15 +477,16 @@ function pmprogroupacct_shortcode_manage_group() {
 									foreach ( $active_members as $member ) {
 										$user  = get_userdata( $member->group_child_user_id );
 										if ( ! empty( $user ) ) {
-											$username = esc_html( $user->user_login );
+											$user_login = $user->user_login;
 										} else {
-											$username = esc_html__( '[deleted]', 'pmpro-group-accounts' );
+											$user_login = __( '[deleted]', 'pmpro-group-accounts' );
 										}
 
+										//Note: When you delete a membership level, it removes/cancels the level from the user so this will never get here if the level is deleted for a child level.
 										$level = pmpro_getLevel( $member->group_child_level_id );
 										?>
 										<tr>
-											<th data-title="<?php esc_attr_e( 'Username', 'pmpro-group-accounts' ); ?>"><?php echo $username; ?></th>
+											<th data-title="<?php esc_attr_e( 'Username', 'pmpro-group-accounts' ); ?>"><?php echo esc_html( $user_login ); ?></th>
 											<td data-title="<?php esc_attr_e( 'Level', 'pmpro-group-accounts' ); ?>"><?php echo esc_html( $level->name ); ?></td>
 											<td data-title="<?php esc_attr_e( 'Remove', 'pmpro-group-accounts' ); ?>"><input type="checkbox" name="pmprogroupacct_remove_group_members[]" class="<?php echo pmpro_get_element_class( 'input' ); ?>" value="<?php echo esc_attr( $member->id ); ?>"></td>
 										</tr>
@@ -708,20 +709,28 @@ function pmprogroupacct_shortcode_manage_group() {
 								<?php
 								foreach ( $old_members as $member ) {
 									$user = get_userdata( $member->group_child_user_id );
-									if ( empty ( $user ) ) {
-										continue;
+									if ( ! empty ( $user ) ) {
+										$user_login = $user->user_login;
+									} else {
+										$user_login = false;
 									}
 
 									$level = pmpro_getLevel( $member->group_child_level_id );
 									if ( ! empty( $level ) ) {
 										$level_name = $level->name;
 									} else {
-										$level_name = esc_html__( '[deleted]', 'pmpro-group-accounts' );
+										$level_name = false;
 									}
+
+									// Skip this record if both the username and level name are false/deleted.
+									if ( ! $level_name && ! $user_login ) {
+										continue;
+									}
+
 									?>
 									<tr>
-										<td><?php echo esc_html( $user->user_login ); ?></td>
-										<td><?php echo esc_html( $level_name ); ?></td>
+										<td><?php echo ! empty( $user_login ) ? esc_html( $user_login ) : esc_html__( '[deleted]', 'pmpro-group-accounts' ); ?></td>
+										<td><?php echo ! empty( $level_name ) ? esc_html( $level_name ) : esc_html__( '[deleted]', 'pmpro-group-accounts' ); ?></td>
 									</tr>
 									<?php
 								}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-group-accounts/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-group-accounts/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Checking if user exists and if level exists before accessing properties.

Resolves #59
Resolves #51

### How to test the changes in this Pull Request:
1. Create a parent level that has multiple child levels.
2. Checkout for parent level and add children to the child levels.
3. Delete a child level. Check for warnings on Manage Group page.
4. Delete a child account without cancelling their membership. Check for warnings on Manage Group page.
5. Check out for the parent level on a new account. Check for warnings in confirmation email.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fixes warnings that would occur if a child level or child account were deleted.
