### PR TITLE
Fix user with an existing group keeping their number of seats when downgrading to an empty group

### DIFF
--- a/includes/parents.php
+++ b/includes/parents.php
@@ -292,11 +292,6 @@ function pmprogroupacct_pmpro_after_checkout_parent( $user_id ) {
 	// Get the number of seats being purchased.
 	$seats = isset( $_REQUEST['pmprogroupacct_seats'] ) ? intval( $_REQUEST['pmprogroupacct_seats'] ) : 0;
 
-	// There were no seats purchased or included. Bail.
-	if ( ! $seats ) {
-		return;
-	}
-
 	// Check if there is already a group for this user and level.
 	$existing_group = PMProGroupAcct_Group::get_group_by_parent_user_id_and_parent_level_id( $user_id, $level->id );
 	if ( ! empty( $existing_group ) ) {
@@ -304,6 +299,11 @@ function pmprogroupacct_pmpro_after_checkout_parent( $user_id ) {
 		$existing_group->update_group_total_seats( $seats );
 		return;
 	} else {
+		// There were no seats purchased or included. Bail.
+		if ( ! $seats ) {
+			return;
+		}
+
 		// There is not already a group for this user and level. Let's create one.
 		PMProGroupAcct_Group::create( $user_id, $level->id, $seats );
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-group-accounts/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-group-accounts/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Only avoid creating an empty group at checkout when there is not already a group for this user and level.

This was potentially allowing user to pay one time for a recurring group with 10 seats, and then downgrade to 0 seats to pay less while keeping their group to 10 seats.

### How to test the changes in this Pull Request:

1. Create a child level.
2. Create the parent level for this child level with a recurring payment and a variable number of seats ranging from 0 to X.
3. Checkout for the parent level with at least 1 seat.
4. Checkout for the parent level again with 0 seats.
5. Check the Account/Manage Group page.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Side note

Empty group seem to still be created on first checkout with 0 seats because of `pmprogroupacct_create_free_group_if_needed()` but this was out of scope for this fix and I didn't had time to further investigate on the why.

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
