### PR TITLE
Cache the settings array in a static variable to reduce queries

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -28,30 +28,30 @@ function pmprogroupacct_get_settings_for_level( $level_id ) {
  * @return bool True if the level can be claimed using group codes, false otherwise.
  */
 function pmprogroupacct_level_can_be_claimed_using_group_codes( $level_id ) {
-    static $all_settings = null;
+	static $all_settings = null;
 
-    // Make sure that $level_id is an integer.
-    $level_id = intval( $level_id );
+	// Make sure that $level_id is an integer.
+	$level_id = intval( $level_id );
 
-    if ( null === $all_settings ) {
-        global $wpdb;
-        // Get all `pmprogroupacct_settings` metadata for all levels.
-        $all_settings = $wpdb->get_col(
-            $wpdb->prepare(
-                "SELECT meta_value FROM $wpdb->pmpro_membership_levelmeta WHERE meta_key = %s",
-                'pmprogroupacct_settings'
-            )
-        );
-    }
+	if ( null === $all_settings ) {
+		global $wpdb;
+		// Get all `pmprogroupacct_settings` metadata for all levels.
+		$all_settings = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT meta_value FROM $wpdb->pmpro_membership_levelmeta WHERE meta_key = %s",
+				'pmprogroupacct_settings'
+			)
+		);
+	}
 
-    // Check if any of the settings have $level_id in their `child_level_ids` array.
-    foreach ( $all_settings as $setting ) {
-        $setting = maybe_unserialize( $setting );
-        if ( ! empty( $setting['child_level_ids'] ) && in_array( $level_id, $setting['child_level_ids'], true ) ) {
-            return true;
-        }
-    }
-    return false;
+	// Check if any of the settings have $level_id in their `child_level_ids` array.
+	foreach ( $all_settings as $setting ) {
+		$setting = maybe_unserialize( $setting );
+		if ( ! empty( $setting['child_level_ids'] ) && in_array( $level_id, $setting['child_level_ids'], true ) ) {
+			return true;
+		}
+	}
+	return false;
 }
 
 /**


### PR DESCRIPTION
 ### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-group-accounts/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-group-accounts/pulls/) for the same update/change?

### Changes proposed in this Pull Request:

Cache the settings array in a static variable inside the function. This ensures the expensive query only runs once per request.

Every call to `pmprogroupacct_level_can_be_claimed_using_group_codes( $level_id )` runs a database query to fetch _ALL_ group account settings for every level, even though these settings rarely change during a single page load.

### How to test the changes in this Pull Request:

1. Using Query Monitor observe in the admin how `pmprogroupacct_level_can_be_claimed_using_group_codes()` typically results in approximately 43 queries per request.
2. Switch to this branch and reload.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

* Optimize database queries
