### PR TITLE
Removing limit and orderby parameters from get_group_members

### DIFF
--- a/classes/class-pmprogroupacct-group-member.php
+++ b/classes/class-pmprogroupacct-group-member.php
@@ -95,13 +95,6 @@ class PMProGroupAcct_Group_Member {
 
 		$prepared = array();
 		$where    = array();
-		$orderby  = isset( $args['orderby'] ) ? $args['orderby'] : '`id` DESC';
-		$limit    = isset( $args['limit'] ) ? (int) $args['limit'] : 100;
-
-		// Detect unsupported orderby usage.
-		if ( $orderby !== preg_replace( '/[^a-zA-Z0-9\s,`]/', ' ', $orderby ) ) {
-			return [];
-		}
 
 		// Filter by ID.
 		if ( isset( $args['id'] ) ) {
@@ -136,11 +129,6 @@ class PMProGroupAcct_Group_Member {
 		// Maybe filter the data.
 		if ( ! empty( $where ) ) {
 			$sql_query .= ' WHERE ' . implode( ' AND ', $where );
-		}
-	
-		// Add the order and limit if we're not just counting.
-		if ( empty( $args['return_count'] ) ) {
-			$sql_query .= " ORDER BY {$orderby} LIMIT {$limit}";
 		}
 	
 		// Prepare the query.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-group-accounts/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-group-accounts/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Fixes issue where only 100 members would appear when listing the members in a group when the "member count" for a group is actually above 100.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
