### PR TITLE
Fixing placeholder text for pmprogroupacct_transfer_group_code

### DIFF
--- a/includes/manage-group-page.php
+++ b/includes/manage-group-page.php
@@ -718,7 +718,7 @@ function pmprogroupacct_shortcode_manage_group() {
 											$bulk_member_actions[] = array(
 												'label'            => __( 'Transfer', 'pmpro-group-accounts' ),
 												'confirm'          => __( 'Are you sure you want to transfer these users to another group?', 'pmpro-group-accounts' ),
-												'conditional_html' => '<input type="text" name="pmprogroupacct_transfer_group_code" class="' . esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-checkbox' ) ) . '" placeholder="' . esc_attr__( 'Enter Group ID', 'pmpro-group-accounts' ) . '" />',
+												'conditional_html' => '<input type="text" name="pmprogroupacct_transfer_group_code" class="' . esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-checkbox' ) ) . '" placeholder="' . esc_attr__( 'Enter Group Code', 'pmpro-group-accounts' ) . '" />',
 												'action'           => 'transfer',
 											);
 										}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-group-accounts/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-group-accounts/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Fixing the placeholder text for the `pmprogroupacct_transfer_group_code` that expects a "group code" to be passed, not a "group ID".

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
