### PR TITLE
[ENHANCEMENT] Add support for pre-filling group seats via URL parameter

### DIFF
--- a/includes/parents.php
+++ b/includes/parents.php
@@ -75,6 +75,16 @@ function pmprogroupacct_pmpro_checkout_boxes_parent() {
 	}
 	$child_levels_message = sprintf( _n( 'Group members will be able to claim the %s membership level.', 'Group members will be able to claim the following membership levels: %s.', count( $child_level_names ) ,'pmpro-group-accounts' ), implode( ', ', $child_level_names ) );
 
+	// Get the default number of seats. Check if a seat quantity was passed via URL parameter.
+	$default_seats = $settings['min_seats'];
+	if ( isset( $_REQUEST['pmprogroupacct_chosen_seats'] ) ) {
+		$requested_seats = intval( $_REQUEST['pmprogroupacct_chosen_seats'] );
+		// Validate that the requested seats are within the allowed range.
+		if ( $requested_seats >= $settings['min_seats'] && $requested_seats <= $settings['max_seats'] ) {
+			$default_seats = $requested_seats;
+		}
+	}
+
 	// Build the checkout box.
 	// We can check if there are a variable amount of seats by checking if min_seats is equal to max_seats.
 	// The seats option should be a number input defaulting to the minimum seats.
@@ -90,7 +100,7 @@ function pmprogroupacct_pmpro_checkout_boxes_parent() {
 					// Show seats.
 					if ( ! empty( $static_seat_number_message ) ) {
 						?>
-						<input type="hidden" name="pmprogroupacct_seats" value="<?php echo esc_attr( $settings['min_seats'] ); ?>" />
+						<input type="hidden" name="pmprogroupacct_seats" value="<?php echo esc_attr( $default_seats ); ?>" />
 						<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-seats', 'pmpro_form_field-seats' ) ); ?>">
 							<?php echo esc_html( $static_seat_number_message ); ?>
 						</div>
@@ -99,7 +109,7 @@ function pmprogroupacct_pmpro_checkout_boxes_parent() {
 						?>
 						<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-seats', 'pmpro_form_field-seats' ) ); ?>">
 							<label for="pmprogroupacct_seats" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>"><?php esc_html_e( 'Number of Seats', 'pmpro-group-accounts' ); ?></label>
-							<input class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-number pmpro_alter_price', 'pmprogroupacct_seats' ) ); ?>" id="pmprogroupacct_seats" name="pmprogroupacct_seats" type="number" min="<?php echo esc_attr( $settings['min_seats'] ); ?>" max="<?php echo esc_attr( $settings['max_seats'] ); ?>" value="<?php echo esc_attr( $settings['min_seats'] ); ?>" />
+							<input class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-number pmpro_alter_price', 'pmprogroupacct_seats' ) ); ?>" id="pmprogroupacct_seats" name="pmprogroupacct_seats" type="number" min="<?php echo esc_attr( $settings['min_seats'] ); ?>" max="<?php echo esc_attr( $settings['max_seats'] ); ?>" value="<?php echo esc_attr( $default_seats ); ?>" />
 							<p class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_hint' ) ); ?>"><?php printf( esc_html__( 'Choose the number of seats to purchase. You can purchase between %s and %s seats.', 'pmpro-group-accounts' ), esc_html( number_format_i18n( ( (int)$settings['min_seats'] ) ) ), esc_html( number_format_i18n( (int)$settings['max_seats'] ) ) ); ?></p>
 						</div> <!-- end .pmpro_form_field-seats -->
 						<?php


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-group-accounts/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-group-accounts/pulls/) for the same update/change?

### Changes proposed in this Pull Request:

Adds support for pre-filling group seat quantity via URL parameter `pmprogroupacct_chosen_seats`, similar to a feature present in Payment Plans. This allows direct links to checkout with a specific number of seats pre-selected, improving user experience for marketing campaigns and developers.

### How to test the changes in this Pull Request:

1. Configure a group parent level with variable seats (e.g., min=5, max=20)
2. Visit checkout URL with parameter: `?pmpro_level=X&pmprogroupacct_chosen_seats=10`
3. Verify the seats field is pre-filled with 10
4. Test with out-of-range values to confirm they fall back to minimum seats
5. Test with fixed seat levels to confirm existing behavior is maintained

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

Added support for `pmprogroupacct_chosen_seats` URL parameter to pre-fill group seat quantity at checkout. Values are validated against min/max seat limits with secure fallback to minimum seats.

> **Note**: This feature was developed with the assistance of AI.