### PR TITLE
Fixes child account status to match parent account on cancel and expire

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -358,16 +358,23 @@ function pmprogroupacct_manage_memberslist_column_body( $column_name, $user_id, 
 	// Populate the parent account column.
 	if ( 'pmprogroupacct_parent' === $column_name ) {
 		// Get the user's group member object for the membership level being shown.
-		$group_member_query_args = array(
+		// First try active, then fall back to inactive for Old/Expired/Cancelled Members views.
+		$group_members = PMProGroupAcct_Group_Member::get_group_members( array(
 			'group_child_user_id'  => $user_id,
 			'group_child_level_id' => $item['membership_id'],
 			'group_child_status'   => 'active',
-		);
-		$group_members = PMProGroupAcct_Group_Member::get_group_members( $group_member_query_args );
+		) );
+
+		if ( empty( $group_members ) ) {
+			$group_members = PMProGroupAcct_Group_Member::get_group_members( array(
+				'group_child_user_id'  => $user_id,
+				'group_child_level_id' => $item['membership_id'],
+			) );
+		}
 
 		// If the membership is a group membership, get the group information.
 		if ( ! empty( $group_members) ) {
-			$group_id = $group_members[0]->group_id;	
+			$group_id = $group_members[0]->group_id;
 			$group = new PMProGroupAcct_Group( $group_id );
 			$parent_user = get_userdata( $group->group_parent_user_id );
 			$parent_user_info = empty( $parent_user ) ? esc_html( $group->group_parent_user_id ) : '<a href="' . esc_url( pmprogroupacct_member_edit_url_for_user( $parent_user ) ) . '">' . esc_html( $parent_user->user_login ) . '</a>';
@@ -405,23 +412,27 @@ add_filter( 'pmpro_members_list_csv_extra_columns', 'pmprogroupacct_members_list
  */
 function pmprogroupacct_members_list_csv_extra_columns_parent_account( $user ) {
 	// Get the user's group member object for the membership level in this row.
-	$group_member_query_args = array(
+	// First try active, then fall back to inactive for exported Old/Expired/Cancelled Members.
+	$group_members = PMProGroupAcct_Group_Member::get_group_members( array(
 		'group_child_user_id'  => $user->ID,
 		'group_child_level_id' => $user->membership_id,
 		'group_child_status'   => 'active',
-	);
-	$group_members = PMProGroupAcct_Group_Member::get_group_members( $group_member_query_args );
+	) );
+
+	if ( empty( $group_members ) ) {
+		$group_members = PMProGroupAcct_Group_Member::get_group_members( array(
+			'group_child_user_id'  => $user->ID,
+			'group_child_level_id' => $user->membership_id,
+		) );
+	}
 
 	// If the membership is a group membership, get the group information.
-	if ( ! empty( $group_members) ) {
+	if ( ! empty( $group_members ) ) {
 		$group_id = $group_members[0]->group_id;
 		$group = new PMProGroupAcct_Group( $group_id );
 		$parent_user = get_userdata( $group->group_parent_user_id );
 		return ! empty( $parent_user ) ? $parent_user->user_login : '';
-	} else {
-		return '';
 	}
-  
-  // If we make it here, lets just return nothing.
-  return '';
+
+	return '';
 }

--- a/includes/parents.php
+++ b/includes/parents.php
@@ -322,6 +322,8 @@ add_action( 'pmpro_after_checkout', 'pmprogroupacct_pmpro_after_checkout_parent'
  * @param $old_user_levels array The old levels the users had.
  */
 function pmprogroupacct_pmpro_after_all_membership_level_changes_parent( $old_user_levels ) {
+		
+	global $wpdb;
 	// Track if we cancel a membership during this function.
 	// If so, we need to make sure to run pmpro_do_action_after_all_membership_level_changes() afterwards.
 	$cancelled_membership = false;
@@ -347,6 +349,14 @@ function pmprogroupacct_pmpro_after_all_membership_level_changes_parent( $old_us
 		foreach ( $lost_level_ids as $lost_level_id ) {
 			$existing_group = PMProGroupAcct_Group::get_group_by_parent_user_id_and_parent_level_id( $user_id, $lost_level_id );
 			if ( ! empty( $existing_group ) ) {
+				// Determine what status to apply to child accounts based on why the parent lost the level.
+				$parent_level_status = $wpdb->get_var( $wpdb->prepare(
+					"SELECT status FROM {$wpdb->pmpro_memberships_users} WHERE user_id = %d AND membership_id = %d ORDER BY id DESC LIMIT 1",
+					$user_id,
+					$lost_level_id
+				) );
+				$child_status = ( $parent_level_status === 'expired' ) ? 'expired' : 'cancelled';
+
 				// There is a group for this parent and level. Let's get all the active members for this group and cancel their group level.
 				$active_members = $existing_group->get_active_members();
 				foreach ( $active_members as $active_member ) {
@@ -356,14 +366,15 @@ function pmprogroupacct_pmpro_after_all_membership_level_changes_parent( $old_us
 						PMPro_Action_Scheduler::instance()->maybe_add_task(
 							'pmpro_groupacct_cancel_user_membership',
 							array(
-								'user_id'       => $active_member->group_child_user_id,
+								'user_id'  => $active_member->group_child_user_id,
 								'level_id' => $active_member->group_child_level_id,
+								'status'   => $child_status,
 							),
 							'pmpro_groupacct_tasks'
 						);
 					} else {
 						// We don't have Action Scheduler. Just try to cancel the membership now.
-						pmpro_cancelMembershipLevel( $active_member->group_child_level_id, $active_member->group_child_user_id );
+						pmpro_cancelMembershipLevel( $active_member->group_child_level_id, $active_member->group_child_user_id, $child_status );
 						$cancelled_membership = true;
 					}
 				}
@@ -383,17 +394,18 @@ add_action( 'pmpro_after_all_membership_level_changes', 'pmprogroupacct_pmpro_af
 /**
  * Callback to cancel a specific membership level for a user.
  *
- * @param int $user_id The user ID to cancel the membership for.
- * @param int $level_id The membership level ID to cancel.
+ * @param int    $user_id  The user ID to cancel the membership for.
+ * @param int    $level_id The membership level ID to cancel.
+ * @param string $status   The status to set. 'expired' or 'cancelled'. Defaults to 'cancelled'.
  */
-function pmprogroupacct_cancel_user_membership( $user_id, $level_id ) {
-	// Cancel the user's membership level.
-	pmpro_cancelMembershipLevel( $level_id, $user_id );
+function pmprogroupacct_cancel_user_membership( $user_id, $level_id, $status = 'cancelled' ) {
+	// Cancel the user's membership level with the appropriate status.
+	pmpro_cancelMembershipLevel( $level_id, $user_id, $status );
 
 	// Run any actions needed after all membership level changes.
 	pmpro_do_action_after_all_membership_level_changes();
 }
-add_action( 'pmpro_groupacct_cancel_user_membership', 'pmprogroupacct_cancel_user_membership', 10, 2 );
+add_action( 'pmpro_groupacct_cancel_user_membership', 'pmprogroupacct_cancel_user_membership', 10, 3 );
 
 /**
  * Add an invoice bullet if the level purchased with the invoice that we are showing


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-group-accounts/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-group-accounts/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When a parent's membership expires, child accounts are now set to expired (previously they were set to inactive, causing them to appear only under Old Members and count as cancellations instead of expirations)

When a parent's membership is cancelled, child accounts are now correctly set to cancelled

The Parent Account column in the Members List now displays the parent username for child accounts in the Old Members, Expired Members, and Cancelled Members views (previously it only resolved for active members)

The same Parent Account fix applies to the Members List CSV export

### How to test the changes in this Pull Request:

**Test 1: Parent expires → children expire**

Set up a parent user with an active group and at least one child member
Force-expire the parent's membership (set enddate to past and run pmpro_membership_expiration_check(), or set status to expired in DB and trigger pmpro_do_action_after_all_membership_level_changes())
Confirm child membership is removed
Check Expired Members list → child should appear
Check Reports → Signups vs. Expirations → child should count as an expiration
Confirm child does not appear in Cancelled Members

**Test 2: Parent cancels → children cancel**

Same setup as above
Cancel the parent's membership via admin or front-end
Confirm child membership is removed
Check Cancelled Members list → child should appear
Check Reports → Signups vs. Cancellations → child should count as a cancellation
Confirm child does not appear in Expired Members

**Test 3: Parent Account column in non-active lists**

After either test above, go to Old Members, Expired Members, or Cancelled Members in the Members List
Find the child user row
Confirm the Parent Account column shows the parent's username with a link (not a dash)
Confirm the CSV export also includes the parent username for the child row

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

