### PR TITLE
Importing Child Accounts Can Use Parent Email

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -313,19 +313,15 @@ function pmprogroupacct_pmproiucsv_post_user_import( $user, $membership_id, $ord
 		}
 	}
 
-	// If $group_id is not numeric, try to resolve it from an email address or user login.
-	if ( ! empty( $group_id ) && ! is_numeric( $group_id ) ) {
+	// Check if the group ID is an email address. If so, look up the user and group associated with that email address. This allows imports to reference a parent account by email instead of group code or group ID.
+	if ( ! empty( $group_id ) ) {
 		if ( is_email( $group_id ) ) {
-			$parent_user = get_user_by( 'email', $group_id );
-		} else {
-			$parent_user = get_user_by( 'login', $group_id );
-		}
-
-		if ( ! empty( $parent_user ) ) {
-			$parent_groups = PMProGroupAcct_Group::get_groups( array( 'group_parent_user_id' => $parent_user->ID, 'limit' => 1 ) );
+			$parent_user   = get_user_by( 'email', $group_id );
+			$parent_groups = ! empty( $parent_user ) ? PMProGroupAcct_Group::get_groups( array( 'group_parent_user_id' => $parent_user->ID, 'limit' => 1 ) ) : array();
 			$group_id      = ! empty( $parent_groups ) ? $parent_groups[0]->id : '';
 		} else {
-			$group_id = '';
+			$group    = PMProGroupAcct_Group::get_group_by_checkout_code( $group_id );
+			$group_id = ! empty( $group ) ? $group->id : '';
 		}
 	}
 

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -313,6 +313,22 @@ function pmprogroupacct_pmproiucsv_post_user_import( $user, $membership_id, $ord
 		}
 	}
 
+	// If $group_id is not numeric, try to resolve it from an email address or user login.
+	if ( ! empty( $group_id ) && ! is_numeric( $group_id ) ) {
+		if ( is_email( $group_id ) ) {
+			$parent_user = get_user_by( 'email', $group_id );
+		} else {
+			$parent_user = get_user_by( 'login', $group_id );
+		}
+
+		if ( ! empty( $parent_user ) ) {
+			$parent_groups = PMProGroupAcct_Group::get_groups( array( 'group_parent_user_id' => $parent_user->ID, 'limit' => 1 ) );
+			$group_id      = ! empty( $parent_groups ) ? $parent_groups[0]->id : '';
+		} else {
+			$group_id = '';
+		}
+	}
+
 	// Add the child account if the level is a child level and passed through a group ID.
 	if ( ! empty( $group_id ) && pmprogroupacct_level_can_be_claimed_using_group_codes( $membership_id ) ) {
 		
@@ -358,16 +374,23 @@ function pmprogroupacct_manage_memberslist_column_body( $column_name, $user_id, 
 	// Populate the parent account column.
 	if ( 'pmprogroupacct_parent' === $column_name ) {
 		// Get the user's group member object for the membership level being shown.
-		$group_member_query_args = array(
+		// First try active, then fall back to inactive for Old/Expired/Cancelled Members views.
+		$group_members = PMProGroupAcct_Group_Member::get_group_members( array(
 			'group_child_user_id'  => $user_id,
 			'group_child_level_id' => $item['membership_id'],
 			'group_child_status'   => 'active',
-		);
-		$group_members = PMProGroupAcct_Group_Member::get_group_members( $group_member_query_args );
+		) );
+
+		if ( empty( $group_members ) ) {
+			$group_members = PMProGroupAcct_Group_Member::get_group_members( array(
+				'group_child_user_id'  => $user_id,
+				'group_child_level_id' => $item['membership_id'],
+			) );
+		}
 
 		// If the membership is a group membership, get the group information.
 		if ( ! empty( $group_members) ) {
-			$group_id = $group_members[0]->group_id;	
+			$group_id = $group_members[0]->group_id;
 			$group = new PMProGroupAcct_Group( $group_id );
 			$parent_user = get_userdata( $group->group_parent_user_id );
 			$parent_user_info = empty( $parent_user ) ? esc_html( $group->group_parent_user_id ) : '<a href="' . esc_url( pmprogroupacct_member_edit_url_for_user( $parent_user ) ) . '">' . esc_html( $parent_user->user_login ) . '</a>';
@@ -405,23 +428,27 @@ add_filter( 'pmpro_members_list_csv_extra_columns', 'pmprogroupacct_members_list
  */
 function pmprogroupacct_members_list_csv_extra_columns_parent_account( $user ) {
 	// Get the user's group member object for the membership level in this row.
-	$group_member_query_args = array(
+	// First try active, then fall back to inactive for exported Old/Expired/Cancelled Members.
+	$group_members = PMProGroupAcct_Group_Member::get_group_members( array(
 		'group_child_user_id'  => $user->ID,
 		'group_child_level_id' => $user->membership_id,
 		'group_child_status'   => 'active',
-	);
-	$group_members = PMProGroupAcct_Group_Member::get_group_members( $group_member_query_args );
+	) );
+
+	if ( empty( $group_members ) ) {
+		$group_members = PMProGroupAcct_Group_Member::get_group_members( array(
+			'group_child_user_id'  => $user->ID,
+			'group_child_level_id' => $user->membership_id,
+		) );
+	}
 
 	// If the membership is a group membership, get the group information.
-	if ( ! empty( $group_members) ) {
+	if ( ! empty( $group_members ) ) {
 		$group_id = $group_members[0]->group_id;
 		$group = new PMProGroupAcct_Group( $group_id );
 		$parent_user = get_userdata( $group->group_parent_user_id );
 		return ! empty( $parent_user ) ? $parent_user->user_login : '';
-	} else {
-		return '';
 	}
-  
-  // If we make it here, lets just return nothing.
-  return '';
+
+	return '';
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-group-accounts/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-group-accounts/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Importing child accounts and using the `pmprogroupacct_group_id` column accepts the group ID, or the email. This makes it easier to prepare the second import file ahead of time without having get the group ID that was created.

### How to test the changes in this Pull Request:

1. Create two files, ensure they meet standard Import for Users from CSV formats
2. Parent file must have the seats column
3. Child account must have the group_id column
4. Set the group_id value for the child account to a parent account email and import

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

