### PR TITLE
Add form to generate group with number of seats.

### DIFF
--- a/includes/edit-member.php
+++ b/includes/edit-member.php
@@ -57,6 +57,9 @@ add_action( 'admin_init', 'pmprogroupacct_hook_edit_member_profile', 0 );
 function pmprogroupacct_show_group_account_info( $user ) {
 	global $pmpro_pages;
 
+	// Show any notice set by the generate-group handler on the previous request.
+	pmprogroupacct_maybe_render_generate_group_notice();
+
 	// Get all groups that the user manages.
 	$group_query_args = array(
 		'group_parent_user_id' => (int)$user->ID,
@@ -69,12 +72,37 @@ function pmprogroupacct_show_group_account_info( $user ) {
 	);
 	$group_members = PMProGroupAcct_Group_Member::get_group_members( $group_member_query_args );
 
+	// Figure out which of the user's parent-eligible levels do not yet have a group
+	// so we can offer an inline "Generate Group" form for each one. This supports
+	// users who hold multiple parent-level memberships at once.
+	$levels_without_groups = array();
+	if ( function_exists( 'pmpro_getMembershipLevelsForUser' ) ) {
+		$user_levels = pmpro_getMembershipLevelsForUser( $user->ID );
+		if ( ! empty( $user_levels ) ) {
+			$existing_parent_level_ids = wp_list_pluck( $groups, 'group_parent_level_id' );
+			foreach ( $user_levels as $user_level ) {
+				$level_settings = pmprogroupacct_get_settings_for_level( $user_level->id );
+				if ( empty( $level_settings ) || empty( $level_settings['child_level_ids'] ) ) {
+					continue;
+				}
+				if ( in_array( (int)$user_level->id, array_map( 'intval', $existing_parent_level_ids ), true ) ) {
+					continue;
+				}
+				$levels_without_groups[] = $user_level;
+			}
+		}
+	}
+
 	// Show the UI.
 	?>
 	<h3><?php esc_html_e( 'Manage Groups', 'pmpro-group-accounts' ); ?></h3>
 	<?php
 	if ( empty( $groups ) ) {
-		echo '<p>' . esc_html__( 'This user does not manage any groups.', 'pmpro-group-accounts' ) . '</p>';
+		if ( empty( $levels_without_groups ) ) {
+			echo '<p>' . esc_html__( 'This user does not manage any groups.', 'pmpro-group-accounts' ) . '</p>';
+		} else {
+			echo '<p>' . esc_html__( 'This user has a parent-eligible membership level but does not yet have a group. Generate a group below to provide them with a checkout code.', 'pmpro-group-accounts' ) . '</p>';
+		}
 	} else {
 		// Show the groups that the user manages.
 		?>
@@ -138,8 +166,13 @@ function pmprogroupacct_show_group_account_info( $user ) {
 				}
 				?>
 			</tbody>
-		</table> 
+		</table>
 		<?php
+	}
+
+	// Show a "Generate Group" form for each parent-eligible level the user holds that has no group yet.
+	if ( ! empty( $levels_without_groups ) ) {
+		pmprogroupacct_render_generate_group_forms( $user, $levels_without_groups );
 	}
 	?>
 	<h3><?php esc_html_e( 'Manage Child Memberships', 'pmpro-group-accounts' ); ?></h3>
@@ -199,4 +232,100 @@ function pmprogroupacct_show_group_account_info( $user ) {
 		</table> 
 		<?php
 	}
+}
+
+/**
+ * Handle the "Generate Group" form submission on the Edit Member panel.
+ *
+ * Runs early on admin_init so that we can process the POST before PMPro's
+ * main member-save flow runs — otherwise auto-created "free groups" can
+ * appear before our handler and swallow the admin-entered seat count.
+ *
+ * If a group already exists for the user/level (e.g. was just auto-created
+ * with 0 seats), we update its seat count instead of creating a new one.
+ *
+ * @since 1.5.3
+ */
+function pmprogroupacct_maybe_handle_generate_group_form() {
+	if ( empty( $_POST['pmprogroupacct_generate_group_submit'] ) || empty( $_POST['pmprogroupacct_generate_group_level_id'] ) ) {
+		return;
+	}
+
+	$level_id = (int) $_POST['pmprogroupacct_generate_group_level_id'];
+	$user_id  = isset( $_POST['pmprogroupacct_generate_group_user_id'] ) ? (int) $_POST['pmprogroupacct_generate_group_user_id'] : 0;
+
+	if ( empty( $user_id ) || empty( $level_id ) ) {
+		return;
+	}
+
+	if ( ! current_user_can( 'pmpro_edit_members' ) && ! current_user_can( 'edit_users' ) ) {
+		return;
+	}
+
+	if ( empty( $_POST['pmprogroupacct_generate_group_nonce'] ) || ! wp_verify_nonce( sanitize_key( $_POST['pmprogroupacct_generate_group_nonce'] ), 'pmprogroupacct_generate_group_' . $user_id . '_' . $level_id ) ) {
+		pmprogroupacct_set_generate_group_notice( 'error', __( 'Unable to generate group: security check failed.', 'pmpro-group-accounts' ) );
+		return;
+	}
+
+	// Confirm the user still has this level and that the level is a parent level.
+	if ( ! pmpro_hasMembershipLevel( $level_id, $user_id ) ) {
+		pmprogroupacct_set_generate_group_notice( 'error', __( 'Unable to generate group: this user does not have that membership level.', 'pmpro-group-accounts' ) );
+		return;
+	}
+	$settings = pmprogroupacct_get_settings_for_level( $level_id );
+	if ( empty( $settings ) || empty( $settings['child_level_ids'] ) ) {
+		pmprogroupacct_set_generate_group_notice( 'error', __( 'Unable to generate group: that level is not configured for group accounts.', 'pmpro-group-accounts' ) );
+		return;
+	}
+
+	$seats = isset( $_POST['pmprogroupacct_generate_group_seats'] ) ? max( 0, (int) $_POST['pmprogroupacct_generate_group_seats'] ) : 0;
+
+	// If a group already exists (e.g. auto-created as an empty free group), update its seats.
+	$existing_group = PMProGroupAcct_Group::get_group_by_parent_user_id_and_parent_level_id( $user_id, $level_id );
+	if ( ! empty( $existing_group ) ) {
+		$existing_group->update_group_total_seats( $seats );
+		pmprogroupacct_set_generate_group_notice( 'success', __( 'Group seats updated successfully.', 'pmpro-group-accounts' ) );
+	} else {
+		$group = PMProGroupAcct_Group::create( $user_id, $level_id, $seats );
+		if ( empty( $group ) ) {
+			pmprogroupacct_set_generate_group_notice( 'error', __( 'Unable to generate group. Please try again.', 'pmpro-group-accounts' ) );
+			return;
+		}
+		pmprogroupacct_set_generate_group_notice( 'success', __( 'Group generated successfully.', 'pmpro-group-accounts' ) );
+	}
+
+	// Redirect to avoid the outer Edit Member form reprocessing the submission.
+	$redirect_url = remove_query_arg( array( 'pmprogroupacct_generated' ) );
+	$redirect_url = wp_get_referer() ? wp_get_referer() : $redirect_url;
+	wp_safe_redirect( $redirect_url );
+	exit;
+}
+add_action( 'admin_init', 'pmprogroupacct_maybe_handle_generate_group_form', 5 );
+
+/**
+ * Store a transient notice for the current user about the generate-group action.
+ *
+ * @since 1.5.3
+ *
+ * @param string $type    Either 'success' or 'error'.
+ * @param string $message The message to display.
+ */
+function pmprogroupacct_set_generate_group_notice( $type, $message ) {
+	set_transient( 'pmprogroupacct_generate_notice_' . get_current_user_id(), array( 'type' => $type, 'message' => $message ), 30 );
+}
+
+/**
+ * Render (and clear) any pending notice set by the generate-group handler.
+ *
+ * @since 1.5.3
+ */
+function pmprogroupacct_maybe_render_generate_group_notice() {
+	$key    = 'pmprogroupacct_generate_notice_' . get_current_user_id();
+	$notice = get_transient( $key );
+	if ( empty( $notice ) || empty( $notice['message'] ) ) {
+		return;
+	}
+	delete_transient( $key );
+	$class = $notice['type'] === 'success' ? 'notice-success' : 'notice-error';
+	echo '<div class="notice ' . esc_attr( $class ) . '"><p>' . esc_html( $notice['message'] ) . '</p></div>';
 }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -72,3 +72,51 @@ function pmprogroupacct_member_edit_url_for_user( $user ) {
 	// Return the parent user edit URL.
 	return $member_edit_url;
 }
+
+/**
+ * Render a "Generate Group" form for each parent-eligible level the user
+ * holds that does not yet have a group associated with it.
+ *
+ * @since 1.5.3
+ *
+ * @param WP_User $user The user being edited.
+ * @param array   $levels The user's parent-eligible levels without a group.
+ */
+function pmprogroupacct_render_generate_group_forms( $user, $levels ) {
+	?>
+	<h4><?php esc_html_e( 'Generate Parent Group', 'pmpro-group-accounts' ); ?></h4>
+	<p class="description"><?php esc_html_e( 'Create a group and checkout code for this user so they can invite members.', 'pmpro-group-accounts' ); ?></p>
+	<?php
+	foreach ( $levels as $level ) {
+		$settings      = pmprogroupacct_get_settings_for_level( $level->id );
+		$min_seats     = ! empty( $settings['min_seats'] ) ? (int)$settings['min_seats'] : 0;
+		$max_seats     = ! empty( $settings['max_seats'] ) ? (int)$settings['max_seats'] : 0;
+		$default_seats = $max_seats > 0 ? $max_seats : $min_seats;
+		$input_id      = 'pmprogroupacct_generate_seats_' . (int)$level->id;
+		?>
+		<form method="post" style="margin: 0 0 1em 0;">
+			<?php wp_nonce_field( 'pmprogroupacct_generate_group_' . (int)$user->ID . '_' . (int)$level->id, 'pmprogroupacct_generate_group_nonce' ); ?>
+			<input type="hidden" name="pmprogroupacct_generate_group_user_id" value="<?php echo esc_attr( (int)$user->ID ); ?>" />
+			<input type="hidden" name="pmprogroupacct_generate_group_level_id" value="<?php echo esc_attr( (int)$level->id ); ?>" />
+			<p><strong><?php echo esc_html( sprintf( __( 'Parent Level: %s', 'pmpro-group-accounts' ), $level->name ) ); ?></strong></p>
+			<table class="form-table">
+				<tr>
+					<th scope="row"><label for="<?php echo esc_attr( $input_id ); ?>"><?php esc_html_e( 'Number of Seats', 'pmpro-group-accounts' ); ?></label></th>
+					<td>
+						<input id="<?php echo esc_attr( $input_id ); ?>" type="number" min="0" max="4294967295" name="pmprogroupacct_generate_group_seats" value="<?php echo esc_attr( $default_seats ); ?>" />
+						<?php submit_button( __( 'Generate Group', 'pmpro-group-accounts' ), 'secondary', 'pmprogroupacct_generate_group_submit', false ); ?>
+						<?php if ( $min_seats || $max_seats ) { ?>
+							<p class="description">
+								<?php
+								/* translators: 1: min seats, 2: max seats. */
+								echo esc_html( sprintf( __( 'Level default range: %1$s to %2$s seats.', 'pmpro-group-accounts' ), number_format_i18n( $min_seats ), number_format_i18n( $max_seats ) ) );
+								?>
+							</p>
+						<?php } ?>
+					</td>
+				</tr>
+			</table>
+		</form>
+		<?php
+	}
+}

--- a/includes/parents.php
+++ b/includes/parents.php
@@ -333,14 +333,15 @@ function pmprogroupacct_pmpro_after_all_membership_level_changes_parent( $old_us
 
 		// Get the new level for this user.
 		$new_levels    = pmpro_getMembershipLevelsForUser( $user_id );
-		$new_level_ids = wp_list_pluck( $new_levels, 'id' );		
+		$new_level_ids = wp_list_pluck( $new_levels, 'id' );
 
-		// Make sure the user has a group for any group parent levels they gained.
+		// For levels the user just gained, auto-create a group only when the level has a fixed
+		// seat count (min_seats === max_seats). Variable-seat levels wait for checkout or for an
+		// admin to generate the group manually, since the seat count is not predetermined.
 		$received_level_ids = array_diff( $new_level_ids, $old_level_ids );
 		foreach ( $received_level_ids as $received_level_id ) {
 			pmprogroupacct_create_free_group_if_needed( $user_id, $received_level_id );
 		}
-
 
 		// Check if the parent has a group for any of the levels they lost.
 		$lost_level_ids = array_diff( $old_level_ids, $new_level_ids );
@@ -379,6 +380,32 @@ function pmprogroupacct_pmpro_after_all_membership_level_changes_parent( $old_us
 }
 // Hook at a late priority since we may change further levels and need to run pmpro_do_action_after_all_membership_level_changes() again.
 add_action( 'pmpro_after_all_membership_level_changes', 'pmprogroupacct_pmpro_after_all_membership_level_changes_parent', 20, 1 );
+
+/**
+ * When a user logs in, check if they have all needed groups for their levels.
+ * If not, create empty groups for them.
+ *
+ * @since 1.0.1
+ * @deprecated 1.5.3 No longer hooked. Groups are now only created at checkout or via the admin "Generate Group" form.
+ *
+ * @param string $user_login The user's login.
+ * @param WP_User $user The user object.
+ */
+function pmprogroupacct_wp_login_parent( $user_login, $user ) {
+	// Make sure that PMPro is enabled.
+	if ( ! function_exists( 'pmpro_getMembershipLevelsForUser' ) ) {
+		return;
+	}
+
+	// Get the user's levels.
+	$levels = pmpro_getMembershipLevelsForUser( $user->ID );
+
+	// Loop through the user's levels and create empty groups if needed.
+	foreach ( $levels as $level ) {
+		pmprogroupacct_create_free_group_if_needed( $user->ID, $level->id );
+	}
+}
+add_action( 'wp_login', 'pmprogroupacct_wp_login_parent', 10, 2 );
 
 /**
  * Callback to cancel a specific membership level for a user.
@@ -439,32 +466,6 @@ function pmprogroupacct_pmpro_invoice_bullets_bottom_parent( $invoice ) {
 add_action( 'pmpro_invoice_bullets_bottom', 'pmprogroupacct_pmpro_invoice_bullets_bottom_parent' );
 
 /**
- * When a user logs in, check if they have all needed groups for their levels.
- * If not, create empty groups for them.
- *
- * @since 1.0.1
- *
- * @param string $user_login The user's login.
- * @param WP_User $user The user object.
- */
-function pmprogroupacct_wp_login_parent( $user_login, $user ) {
-	// Make sure that PMPro is enabled.
-	if ( ! function_exists( 'pmpro_getMembershipLevelsForUser' ) ) {
-		return;
-	}
-
-	// Get the user's levels.
-	$levels = pmpro_getMembershipLevelsForUser( $user->ID );
-
-	// Loop through the user's levels and create empty groups if needed.
-	foreach ( $levels as $level ) {
-		pmprogroupacct_create_free_group_if_needed( $user->ID, $level->id );
-	}
-}
-add_action( 'wp_login', 'pmprogroupacct_wp_login_parent', 10, 2 );
-
-
-/**
  * Creates an "free" group if needed for a given parent user and level.
  *
  * A "free" group is a new, empty group that is created with the maximum number
@@ -491,9 +492,14 @@ function pmprogroupacct_create_free_group_if_needed( $user_id, $level_id ) {
 		return;
 	}
 
-	// Create a group for this user and level.
-	// If the pricing model is free, give them the max seats.
-	// Otherwise, give them them 0. The `pmpro_after_checkout` filter will update the seats at chekout if needed.
-	$seats = ( $settings['pricing_model'] === 'none' ) ? $settings['max_seats'] : 0;
-	PMProGroupAcct_Group::create( $user_id, $level_id, $seats );
+	// Only auto-create a group when the seat count is fixed (min_seats === max_seats and > 0).
+	// Variable ranges (e.g. "0 to 10 seats" or "3 to 10 seats") wait for checkout or an admin to
+	// generate the group manually, since we don't know how many seats the parent actually wants.
+	$min_seats = empty( $settings['min_seats'] ) ? 0 : (int) $settings['min_seats'];
+	$max_seats = empty( $settings['max_seats'] ) ? 0 : (int) $settings['max_seats'];
+	if ( $min_seats < 1 || $min_seats !== $max_seats ) {
+		return;
+	}
+
+	PMProGroupAcct_Group::create( $user_id, $level_id, $min_seats );
 }


### PR DESCRIPTION
* BUG/ENHANCEMENT: Fixed autogenerating of group accounts would always run regardless of seat settings. Leaving anyone that signs up for a parent level with optional seats getting a code if the membership was given to them outside of checkout (including logging into their account).

I'm currently building a DIFM for a customer that needs Group Accounts, that are optional. This works at checkout, if you enter 0 seats it bypasses creating the group and code. However, if you manually give the member the same parent level or the log into their site the next time a code is automatically generated with 0 uses. This muddies up the database tables and UI for members that may not want these additional seats.

This PR follows logic of checkout, where if the group code settings allow 0 min seats to bypass this generation entirely. However, a new feature was added to show in the Edit Member panel for managing groups to let an admin create a group with also entering the amount of seats. This reduces navigation clicks for admins and still allows for them to create a group at any time - including any group that may have been deleted from the database.

Autogenerating of groups, outside of checkout, will automatically happen on login or level change when there is a fixed amount of seats or a min of 1+ seat is required. It brings functionality closer to how checkout handles and expected to handle for optional seat/parent levels.

Here is a screenshot example of a parent account that had it's group deleted from the database with fixed seats. In this case it _would also_ generate the group on account login.
<img width="2382" height="701" alt="Screenshot 2026-04-23 at 11 39 39" src="https://github.com/user-attachments/assets/69c3fbbc-4f9e-4aea-9957-2c0977fd0b49" />


### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-group-accounts/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-group-accounts/pulls/) for the same update/change?

### How to test the changes in this Pull Request:

1. Create a parent account with variable seats. Namely 0 - 10 (min-max) seats.
2. Checkout with 0 seats, no code is generated.
3. Logout and log back in, no code is generated.
4. Navigate to the edit member screen of the member from step 1, see the new form as per above with input fields.
5. Submit the form and see that the group is now generated correctly.
6. Test step 1-3 with a fixed amount of seats, as well as giving a new member a level via the WP admin. The group is automatically generated in these cases.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?