### PR TITLE
Add Group Accounts admin page; remove auto-created free groups

### DIFF
--- a/classes/class-pmprogroupacct-group.php
+++ b/classes/class-pmprogroupacct-group.php
@@ -84,72 +84,92 @@ class PMProGroupAcct_Group {
 	 *
 	 * @since 1.0
 	 *
-	 * @param array $args The query arguments to use to retrieve groups.
+	 * @param array $args The query arguments to use to retrieve groups. Supports id,
+	 *                    group_parent_user_id, group_parent_level_id, group_checkout_code,
+	 *                    orderby, limit, offset, status ('active' | 'inactive'), return_count.
 	 *
-	 * @return PMProGroupAcct_Group[] The list of groups.
+	 * @return PMProGroupAcct_Group[]|int The list of groups, or a count when return_count is set.
 	 */
 	public static function get_groups( $args = array() ) {
 		global $wpdb;
-
-		$sql_query = "SELECT id FROM {$wpdb->pmprogroupacct_groups}";
 
 		$prepared = array();
 		$where    = array();
 		$orderby  = isset( $args['orderby'] ) ? $args['orderby'] : '`id` DESC';
 		$limit    = isset( $args['limit'] ) ? (int) $args['limit'] : 100;
+		$offset   = isset( $args['offset'] ) ? (int) $args['offset'] : 0;
+		$status   = isset( $args['status'] ) && in_array( strtolower( (string) $args['status'] ), array( 'active', 'inactive' ), true ) ? strtolower( $args['status'] ) : '';
 
 		// Detect unsupported orderby usage.
 		if ( $orderby !== preg_replace( '/[^a-zA-Z0-9\s,`]/', ' ', $orderby ) ) {
-			return [];
+			return empty( $args['return_count'] ) ? array() : 0;
 		}
 
-		// Filter by ID.
+		// Alias the table as `g` so we can JOIN for the status filter without ambiguity.
+		// DISTINCT is only needed when the status JOIN is active (it can match multiple
+		// rows per group). Without the JOIN, the base table's UNIQUE keys already make
+		// each g.id unique, so DISTINCT is pure overhead.
+		$is_count  = ! empty( $args['return_count'] );
+		$needs_distinct = ( '' !== $status );
+		if ( $is_count ) {
+			$select = $needs_distinct ? 'COUNT(DISTINCT g.id)' : 'COUNT(*)';
+		} else {
+			$select = $needs_distinct ? 'DISTINCT g.id' : 'g.id';
+		}
+		$sql_query = "SELECT {$select} FROM {$wpdb->pmprogroupacct_groups} g";
+
+		// JOIN pmpro_memberships_users when filtering by active/inactive status.
+		if ( '' !== $status ) {
+			$sql_query .= " LEFT JOIN {$wpdb->pmpro_memberships_users} mu ON mu.user_id = g.group_parent_user_id AND mu.membership_id = g.group_parent_level_id AND mu.status = 'active'";
+		}
+
 		if ( isset( $args['id'] ) ) {
-			$where[]    = 'id = %d';
+			$where[]    = 'g.id = %d';
 			$prepared[] = $args['id'];
 		}
-
-		// Filter by parent user ID.
 		if ( isset( $args['group_parent_user_id'] ) ) {
-			$where[]    = 'group_parent_user_id = %d';
+			$where[]    = 'g.group_parent_user_id = %d';
 			$prepared[] = $args['group_parent_user_id'];
 		}
-
-		// Filter by parent level ID.
 		if ( isset( $args['group_parent_level_id'] ) ) {
-			$where[]    = 'group_parent_level_id = %d';
+			$where[]    = 'g.group_parent_level_id = %d';
 			$prepared[] = $args['group_parent_level_id'];
 		}
-
-		// Filter by checkout group_checkout_code.
 		if ( isset( $args['group_checkout_code'] ) ) {
-			$where[]    = 'group_checkout_code = %s';
+			$where[]    = 'g.group_checkout_code = %s';
 			$prepared[] = $args['group_checkout_code'];
 		}
+		if ( 'active' === $status ) {
+			$where[] = 'mu.id IS NOT NULL';
+		} elseif ( 'inactive' === $status ) {
+			$where[] = 'mu.id IS NULL';
+		}
 
-		// Maybe filter the data.
 		if ( ! empty( $where ) ) {
 			$sql_query .= ' WHERE ' . implode( ' AND ', $where );
 		}
 
-		// Add the order and limit.
-		$sql_query .= " ORDER BY {$orderby} LIMIT {$limit}";
-
-		// Prepare the query.
-		if ( ! empty( $prepared ) ) {
-			$sql_query = $wpdb->prepare( $sql_query, $prepared );
+		if ( $is_count ) {
+			if ( ! empty( $prepared ) ) {
+				$sql_query = $wpdb->prepare( $sql_query, $prepared );
+			}
+			return (int) $wpdb->get_var( $sql_query );
 		}
 
-		// Get the data.
+		// Prefix orderby with the `g.` alias so it remains unambiguous when the status JOIN is present.
+		$sql_query .= " ORDER BY g.{$orderby} LIMIT %d OFFSET %d";
+		$prepared[] = $limit;
+		$prepared[] = $offset;
+		$sql_query  = $wpdb->prepare( $sql_query, $prepared );
+
 		$group_ids = $wpdb->get_col( $sql_query );
 		if ( empty( $group_ids ) ) {
 			return array();
 		}
 
-		// Return the list of groups.
 		$groups = array();
 		foreach ( $group_ids as $group_id ) {
-			$group = new self( (int)$group_id );
+			$group = new self( (int) $group_id );
 			if ( ! empty( $group->id ) ) {
 				$groups[] = $group;
 			}

--- a/classes/class-pmprogroupacct-groups-list-table.php
+++ b/classes/class-pmprogroupacct-groups-list-table.php
@@ -1,0 +1,266 @@
+<?php
+
+if ( ! class_exists( 'WP_List_Table' ) ) {
+	require_once ABSPATH . 'wp-admin/includes/class-wp-list-table.php';
+}
+
+/**
+ * List table for all groups in the Group Accounts admin page.
+ *
+ * @since TBD
+ */
+class PMProGroupAcct_Groups_List_Table extends WP_List_Table {
+
+	/**
+	 * @since TBD
+	 */
+	public function __construct() {
+		parent::__construct(
+			array(
+				'plural'   => 'pmprogroupacct_groups',
+				'singular' => 'pmprogroupacct_group',
+				'ajax'     => false,
+			)
+		);
+	}
+
+	/**
+	 * @since TBD
+	 */
+	public function get_columns() {
+		$columns = array(
+			'id'                  => __( 'Group ID', 'pmpro-group-accounts' ),
+			'parent_user'         => __( 'Parent Account', 'pmpro-group-accounts' ),
+			'parent_level'        => __( 'Parent Level', 'pmpro-group-accounts' ),
+			'group_checkout_code' => __( 'Group Code', 'pmpro-group-accounts' ),
+			'seats'               => __( 'Seats', 'pmpro-group-accounts' ),
+			'status'              => __( 'Status', 'pmpro-group-accounts' ),
+		);
+
+		/**
+		 * Filter the columns shown on the Group Accounts admin list table.
+		 *
+		 * @since TBD
+		 *
+		 * @param array $columns Column slug => label.
+		 */
+		return apply_filters( 'pmprogroupacct_manage_groupslist_columns', $columns );
+	}
+
+	/**
+	 * Dispatch column rendering for any column without a dedicated column_<slug> method.
+	 *
+	 * @since TBD
+	 *
+	 * @param PMProGroupAcct_Group $item The group object for this row.
+	 * @param string               $column_name The column slug being rendered.
+	 */
+	public function column_default( $item, $column_name ) {
+		/**
+		 * Render a custom column added via the pmprogroupacct_manage_groupslist_columns filter.
+		 * Callbacks should echo their own escaped HTML for the matching column slug; the return
+		 * value of this method is discarded by WP_List_Table.
+		 *
+		 * @since TBD
+		 *
+		 * @param string               $column_name The column slug being rendered.
+		 * @param PMProGroupAcct_Group $item        The group object for this row.
+		 */
+		do_action( 'pmprogroupacct_manage_grouplist_custom_column', $column_name, $item );
+	}
+
+	/**
+	 * @since TBD
+	 */
+	protected function get_sortable_columns() {
+		return array(
+			'id'           => array( 'id', true ),
+			'parent_user'  => array( 'group_parent_user_id', false ),
+			'parent_level' => array( 'group_parent_level_id', false ),
+			'seats'        => array( 'group_total_seats', false ),
+		);
+	}
+
+	/**
+	 * @since TBD
+	 */
+	public function no_items() {
+		esc_html_e( 'No groups found.', 'pmpro-group-accounts' );
+	}
+
+	/**
+	 * Fetch the groups for the current page and set up pagination.
+	 *
+	 * @since TBD
+	 */
+	public function prepare_items() {
+		$this->_column_headers = array( $this->get_columns(), array(), $this->get_sortable_columns() );
+
+		$per_page     = 20;
+		$current_page = max( 1, $this->get_pagenum() );
+
+		// Build query args common to count and fetch. Validate orderby against the
+		// sortable-columns map so a typo'd URL falls back to the default rather than
+		// blanking the list.
+		$args             = array();
+		$orderby_input    = isset( $_REQUEST['orderby'] ) ? sanitize_key( $_REQUEST['orderby'] ) : 'id';
+		$valid_orderbys   = array();
+		foreach ( $this->get_sortable_columns() as $entry ) {
+			if ( is_array( $entry ) && ! empty( $entry[0] ) ) {
+				$valid_orderbys[] = $entry[0];
+			}
+		}
+		if ( ! in_array( $orderby_input, $valid_orderbys, true ) ) {
+			$orderby_input = 'id';
+		}
+		$order           = ( isset( $_REQUEST['order'] ) && 'asc' === strtolower( $_REQUEST['order'] ) ) ? 'ASC' : 'DESC';
+		$args['orderby'] = $orderby_input . ' ' . $order;
+
+		if ( ! empty( $_REQUEST['l'] ) ) {
+			$args['group_parent_level_id'] = (int) $_REQUEST['l'];
+		}
+
+		if ( ! empty( $_REQUEST['status'] ) ) {
+			$status = sanitize_key( $_REQUEST['status'] );
+			if ( in_array( $status, array( 'active', 'inactive' ), true ) ) {
+				$args['status'] = $status;
+			}
+		}
+
+		$total_items = PMProGroupAcct_Group::get_groups( array_merge( $args, array( 'return_count' => true ) ) );
+		$total_pages = $per_page > 0 ? (int) ceil( $total_items / $per_page ) : 0;
+
+		// Clamp a stale ?paged=N that's past the end of the result set so admins don't
+		// land on an empty page when groups actually exist.
+		if ( $total_items > 0 && $current_page > $total_pages ) {
+			$current_page = $total_pages;
+		}
+
+		$args['limit']  = $per_page;
+		$args['offset'] = ( $current_page - 1 ) * $per_page;
+		$this->items    = PMProGroupAcct_Group::get_groups( $args );
+
+		$this->set_pagination_args(
+			array(
+				'total_items' => $total_items,
+				'per_page'    => $per_page,
+				'total_pages' => $total_pages,
+			)
+		);
+	}
+
+	/**
+	 * Render the Parent Level + Status filter dropdowns above the table.
+	 *
+	 * @since TBD
+	 */
+	protected function extra_tablenav( $which ) {
+		if ( 'top' !== $which ) {
+			return;
+		}
+
+		$selected_level  = isset( $_REQUEST['l'] ) ? (int) $_REQUEST['l'] : 0;
+		$selected_status = ! empty( $_REQUEST['status'] ) ? sanitize_key( $_REQUEST['status'] ) : '';
+		$parent_levels   = pmprogroupacct_get_parent_eligible_levels();
+		?>
+		<div class="alignleft actions">
+			<?php if ( ! empty( $parent_levels ) ) { ?>
+				<label class="screen-reader-text" for="filter-by-parent-level"><?php esc_html_e( 'Filter by parent level', 'pmpro-group-accounts' ); ?></label>
+				<select name="l" id="filter-by-parent-level">
+					<option value="0"><?php esc_html_e( 'All Parent Levels', 'pmpro-group-accounts' ); ?></option>
+					<?php foreach ( $parent_levels as $level ) { ?>
+						<option value="<?php echo esc_attr( $level->id ); ?>" <?php selected( $selected_level, (int) $level->id ); ?>><?php echo esc_html( $level->name ); ?></option>
+					<?php } ?>
+				</select>
+			<?php } ?>
+
+			<label class="screen-reader-text" for="filter-by-status"><?php esc_html_e( 'Filter by status', 'pmpro-group-accounts' ); ?></label>
+			<select name="status" id="filter-by-status">
+				<option value=""><?php esc_html_e( 'All Statuses', 'pmpro-group-accounts' ); ?></option>
+				<option value="active" <?php selected( $selected_status, 'active' ); ?>><?php esc_html_e( 'Active', 'pmpro-group-accounts' ); ?></option>
+				<option value="inactive" <?php selected( $selected_status, 'inactive' ); ?>><?php esc_html_e( 'Inactive', 'pmpro-group-accounts' ); ?></option>
+			</select>
+
+			<?php submit_button( __( 'Filter', 'pmpro-group-accounts' ), '', 'filter_action', false ); ?>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Group ID column — linked to the frontend Manage Group page when available.
+	 *
+	 * @since TBD
+	 */
+	public function column_id( $item ) {
+		$manage_group_url = pmpro_url( 'pmprogroupacct_manage_group' );
+		if ( ! empty( $manage_group_url ) ) {
+			return sprintf(
+				'<strong><a href="%1$s">%2$s</a></strong>',
+				esc_url( add_query_arg( 'pmprogroupacct_group_id', $item->id, $manage_group_url ) ),
+				esc_html( $item->id )
+			);
+		}
+		return '<strong>' . esc_html( $item->id ) . '</strong>';
+	}
+
+	/**
+	 * @since TBD
+	 */
+	public function column_parent_user( $item ) {
+		$parent_user = get_userdata( $item->group_parent_user_id );
+		if ( empty( $parent_user ) ) {
+			return esc_html( $item->group_parent_user_id );
+		}
+		return sprintf(
+			'<a href="%1$s">%2$s</a>',
+			esc_url( pmprogroupacct_member_edit_url_for_user( $parent_user ) ),
+			esc_html( $parent_user->user_login )
+		);
+	}
+
+	/**
+	 * @since TBD
+	 */
+	public function column_parent_level( $item ) {
+		$level = pmpro_getLevel( $item->group_parent_level_id );
+		if ( empty( $level ) ) {
+			/* translators: %d: deleted parent level ID */
+			return esc_html( sprintf( __( '(level %d not found)', 'pmpro-group-accounts' ), $item->group_parent_level_id ) );
+		}
+		return esc_html( $level->name );
+	}
+
+	/**
+	 * @since TBD
+	 */
+	public function column_group_checkout_code( $item ) {
+		return '<code>' . esc_html( $item->group_checkout_code ) . '</code>';
+	}
+
+	/**
+	 * Seats column: "active/total".
+	 *
+	 * @since TBD
+	 */
+	public function column_seats( $item ) {
+		$active = (int) $item->get_active_members( true );
+		$total  = (int) $item->group_total_seats;
+		return esc_html( sprintf( '%s/%s', number_format_i18n( $active ), number_format_i18n( $total ) ) );
+	}
+
+	/**
+	 * Status column: Active when the parent still holds the parent level, else Inactive.
+	 *
+	 * Reuses PMPro core's pmpro_subscription-status badge classes for visual parity
+	 * with the Orders and Subscriptions list tables.
+	 *
+	 * @since TBD
+	 */
+	public function column_status( $item ) {
+		$is_active = pmpro_hasMembershipLevel( (int) $item->group_parent_level_id, (int) $item->group_parent_user_id );
+
+		$label    = $is_active ? __( 'Active', 'pmpro-group-accounts' ) : __( 'Inactive', 'pmpro-group-accounts' );
+		$modifier = $is_active ? 'pmpro_subscription-status-active' : 'pmpro_subscription-status-cancelled';
+		return '<span class="pmpro_subscription-status ' . esc_attr( $modifier ) . '">' . esc_html( $label ) . '</span>';
+	}
+}

--- a/includes/admin-groups.php
+++ b/includes/admin-groups.php
@@ -1,0 +1,323 @@
+<?php
+/**
+ * Group Accounts admin page: list of all groups and form to create new groups.
+ *
+ * @since TBD
+ */
+
+/**
+ * Render the Group Accounts admin page.
+ *
+ * Dispatches on $_REQUEST['action']:
+ *   - '' (default): list table view
+ *   - 'add':        Add Group form
+ *
+ * @since TBD
+ */
+function pmprogroupacct_admin_groups_page() {
+	if ( ! function_exists( 'pmpro_get_edit_member_capability' ) || ! current_user_can( pmpro_get_edit_member_capability() ) ) {
+		wp_die( esc_html__( 'You do not have permission to access this page.', 'pmpro-group-accounts' ) );
+	}
+
+	$action = isset( $_REQUEST['action'] ) ? sanitize_key( $_REQUEST['action'] ) : '';
+	?>
+	<div class="wrap">
+		<h1 class="wp-heading-inline"><?php esc_html_e( 'Group Accounts', 'pmpro-group-accounts' ); ?></h1>
+		<?php if ( 'add' !== $action ) { ?>
+			<a href="<?php echo esc_url( pmprogroupacct_admin_groups_url( array( 'action' => 'add' ) ) ); ?>" class="page-title-action"><?php esc_html_e( 'Add New Group', 'pmpro-group-accounts' ); ?></a>
+		<?php } ?>
+		<hr class="wp-header-end" />
+
+		<?php pmprogroupacct_admin_groups_render_notice(); ?>
+
+		<?php if ( 'add' === $action ) {
+			pmprogroupacct_admin_groups_render_add_form();
+		} else {
+			pmprogroupacct_admin_groups_render_list();
+		} ?>
+	</div>
+	<?php
+}
+
+/**
+ * Render the list view.
+ *
+ * @since TBD
+ */
+function pmprogroupacct_admin_groups_render_list() {
+	$list_table = new PMProGroupAcct_Groups_List_Table();
+	$list_table->prepare_items();
+	?>
+	<form method="get">
+		<input type="hidden" name="page" value="pmpro-groupacct-groups" />
+		<?php
+		// Preserve sort state across filter submissions.
+		if ( ! empty( $_REQUEST['orderby'] ) ) {
+			echo '<input type="hidden" name="orderby" value="' . esc_attr( sanitize_key( wp_unslash( $_REQUEST['orderby'] ) ) ) . '" />';
+		}
+		if ( ! empty( $_REQUEST['order'] ) ) {
+			echo '<input type="hidden" name="order" value="' . esc_attr( sanitize_key( wp_unslash( $_REQUEST['order'] ) ) ) . '" />';
+		}
+		$list_table->display();
+		?>
+	</form>
+	<?php
+}
+
+/**
+ * Render the Add Group form.
+ *
+ * Pre-fills parent user and parent level from query args when provided
+ * (e.g. when arriving from the Edit Member panel's "Create Group" link).
+ *
+ * @since TBD
+ */
+function pmprogroupacct_admin_groups_render_add_form() {
+	$state           = pmprogroupacct_admin_groups_consume_form_state();
+	$errors          = isset( $state['errors'] ) ? (array) $state['errors'] : array();
+	$parent_user_in  = isset( $state['parent_user'] ) ? (string) $state['parent_user'] : '';
+	$parent_level_id = isset( $state['parent_level_id'] ) ? (int) $state['parent_level_id'] : ( isset( $_REQUEST['parent_level_id'] ) ? (int) $_REQUEST['parent_level_id'] : 0 );
+	$seats           = isset( $state['seats'] ) ? (int) $state['seats'] : 0;
+
+	// If we arrived via the Edit Member CTA with a parent_user_id, prefill the user field with their login.
+	if ( '' === $parent_user_in && ! empty( $_REQUEST['parent_user_id'] ) ) {
+		$prefill_user = get_userdata( (int) $_REQUEST['parent_user_id'] );
+		if ( ! empty( $prefill_user ) ) {
+			$parent_user_in = $prefill_user->user_login;
+		}
+	}
+
+	$parent_levels = pmprogroupacct_get_parent_eligible_levels();
+
+	foreach ( $errors as $error_message ) {
+		echo '<div class="notice notice-error"><p>' . esc_html( $error_message ) . '</p></div>';
+	}
+
+	if ( empty( $parent_levels ) ) {
+		?>
+		<div class="notice notice-warning">
+			<p><?php esc_html_e( 'No membership levels are configured for group accounts. Add a child level to a parent level under Memberships → Settings → Levels before creating a group.', 'pmpro-group-accounts' ); ?></p>
+		</div>
+		<?php
+		return;
+	}
+	?>
+	<form method="post" action="<?php echo esc_url( pmprogroupacct_admin_groups_url() ); ?>">
+		<?php wp_nonce_field( 'pmprogroupacct_admin_groups_add', 'pmprogroupacct_admin_groups_nonce' ); ?>
+		<input type="hidden" name="pmprogroupacct_admin_action" value="add" />
+
+		<table class="form-table" role="presentation">
+			<tr>
+				<th scope="row">
+					<label for="pmprogroupacct_parent_user"><?php esc_html_e( 'Parent User', 'pmpro-group-accounts' ); ?></label>
+				</th>
+				<td>
+					<input type="text" id="pmprogroupacct_parent_user" name="pmprogroupacct_parent_user" class="regular-text" value="<?php echo esc_attr( $parent_user_in ); ?>" required />
+					<p class="description"><?php esc_html_e( 'Enter the parent user\'s username or email. They must already hold the chosen parent level.', 'pmpro-group-accounts' ); ?></p>
+				</td>
+			</tr>
+			<tr>
+				<th scope="row">
+					<label for="pmprogroupacct_parent_level_id"><?php esc_html_e( 'Parent Level', 'pmpro-group-accounts' ); ?></label>
+				</th>
+				<td>
+					<select name="pmprogroupacct_parent_level_id" id="pmprogroupacct_parent_level_id" required>
+						<option value=""><?php esc_html_e( '— Select a parent level —', 'pmpro-group-accounts' ); ?></option>
+						<?php foreach ( $parent_levels as $level ) { ?>
+							<option value="<?php echo esc_attr( $level->id ); ?>" <?php selected( $parent_level_id, (int) $level->id ); ?>><?php echo esc_html( $level->name ); ?></option>
+						<?php } ?>
+					</select>
+				</td>
+			</tr>
+			<tr>
+				<th scope="row">
+					<label for="pmprogroupacct_seats"><?php esc_html_e( 'Number of Seats', 'pmpro-group-accounts' ); ?></label>
+				</th>
+				<td>
+					<input type="number" id="pmprogroupacct_seats" name="pmprogroupacct_seats" min="0" max="4294967295" value="<?php echo esc_attr( $seats ); ?>" required />
+				</td>
+			</tr>
+		</table>
+
+		<p class="submit">
+			<?php submit_button( __( 'Create Group', 'pmpro-group-accounts' ), 'primary', 'submit', false ); ?>
+			<a href="<?php echo esc_url( pmprogroupacct_admin_groups_url() ); ?>" class="button"><?php esc_html_e( 'Cancel', 'pmpro-group-accounts' ); ?></a>
+		</p>
+	</form>
+	<?php
+}
+
+/**
+ * Handle the Add Group form submission. Runs on admin_init so we can redirect.
+ *
+ * @since TBD
+ */
+function pmprogroupacct_admin_groups_handle_post() {
+	if ( empty( $_POST['pmprogroupacct_admin_action'] ) ) {
+		return;
+	}
+	if ( 'add' !== sanitize_key( $_POST['pmprogroupacct_admin_action'] ) ) {
+		return;
+	}
+	if ( ! function_exists( 'pmpro_get_edit_member_capability' ) || ! current_user_can( pmpro_get_edit_member_capability() ) ) {
+		return;
+	}
+	if ( empty( $_POST['pmprogroupacct_admin_groups_nonce'] ) || ! wp_verify_nonce( sanitize_key( $_POST['pmprogroupacct_admin_groups_nonce'] ), 'pmprogroupacct_admin_groups_add' ) ) {
+		return;
+	}
+
+	$parent_user_in  = isset( $_POST['pmprogroupacct_parent_user'] ) ? trim( sanitize_text_field( wp_unslash( $_POST['pmprogroupacct_parent_user'] ) ) ) : '';
+	$parent_level_id = isset( $_POST['pmprogroupacct_parent_level_id'] ) ? (int) $_POST['pmprogroupacct_parent_level_id'] : 0;
+	$seats           = isset( $_POST['pmprogroupacct_seats'] ) ? max( 0, (int) $_POST['pmprogroupacct_seats'] ) : 0;
+
+	$errors = array();
+
+	// Resolve the parent user. Email-shaped input tries email first then login, since
+	// users can have logins that look like emails (e.g. when login = email at signup
+	// but the stored email differs).
+	$parent_user = null;
+	if ( '' !== $parent_user_in ) {
+		if ( is_email( $parent_user_in ) ) {
+			$parent_user = get_user_by( 'email', $parent_user_in );
+		}
+		if ( empty( $parent_user ) ) {
+			$parent_user = get_user_by( 'login', $parent_user_in );
+		}
+	}
+	if ( empty( $parent_user ) ) {
+		$errors[] = __( 'Could not find a user with that username or email.', 'pmpro-group-accounts' );
+	}
+
+	$settings = $parent_level_id ? pmprogroupacct_get_settings_for_level( $parent_level_id ) : null;
+	if ( empty( $settings ) || empty( $settings['child_level_ids'] ) ) {
+		$errors[] = __( 'Please choose a parent level that is configured for group accounts.', 'pmpro-group-accounts' );
+	}
+
+	if ( empty( $errors ) && ! pmpro_hasMembershipLevel( $parent_level_id, $parent_user->ID ) ) {
+		$errors[] = __( 'The chosen user does not currently have that membership level. Give them the level first, then create their group.', 'pmpro-group-accounts' );
+	}
+
+	if ( ! empty( $errors ) ) {
+		pmprogroupacct_admin_groups_set_form_state(
+			array(
+				'parent_user'     => $parent_user_in,
+				'parent_level_id' => $parent_level_id,
+				'seats'           => $seats,
+				'errors'          => $errors,
+			)
+		);
+		wp_safe_redirect( pmprogroupacct_admin_groups_url( array( 'action' => 'add' ) ) );
+		exit;
+	}
+
+	// Existing-group short-circuit: redirect to the existing manage-group page.
+	$existing = PMProGroupAcct_Group::get_group_by_parent_user_id_and_parent_level_id( $parent_user->ID, $parent_level_id );
+	if ( ! empty( $existing ) ) {
+		pmprogroupacct_admin_groups_redirect_to_existing_group( $existing );
+	}
+
+	$group = PMProGroupAcct_Group::create( $parent_user->ID, $parent_level_id, $seats );
+	if ( empty( $group ) ) {
+		// Race or duplicate-constraint failure: re-check and route accordingly.
+		$existing = PMProGroupAcct_Group::get_group_by_parent_user_id_and_parent_level_id( $parent_user->ID, $parent_level_id );
+		if ( ! empty( $existing ) ) {
+			pmprogroupacct_admin_groups_redirect_to_existing_group( $existing );
+		}
+
+		pmprogroupacct_admin_groups_set_form_state(
+			array(
+				'parent_user'     => $parent_user_in,
+				'parent_level_id' => $parent_level_id,
+				'seats'           => $seats,
+				'errors'          => array( __( 'Unable to create the group. Please try again.', 'pmpro-group-accounts' ) ),
+			)
+		);
+		wp_safe_redirect( pmprogroupacct_admin_groups_url( array( 'action' => 'add' ) ) );
+		exit;
+	}
+
+	$parent_level = pmpro_getLevel( $parent_level_id );
+	$level_label  = ! empty( $parent_level ) ? $parent_level->name : sprintf( /* translators: %d: parent level ID */ __( 'level #%d', 'pmpro-group-accounts' ), $parent_level_id );
+
+	pmprogroupacct_admin_groups_set_form_state( array( 'notice' => array(
+		'type'    => 'success',
+		'message' => sprintf(
+			/* translators: 1: parent user login, 2: parent level name or fallback */
+			__( 'Group created for %1$s on the %2$s level.', 'pmpro-group-accounts' ),
+			$parent_user->user_login,
+			$level_label
+		),
+	) ) );
+	wp_safe_redirect( pmprogroupacct_admin_groups_url() );
+	exit;
+}
+add_action( 'admin_init', 'pmprogroupacct_admin_groups_handle_post' );
+
+/**
+ * Render (and clear) a pending admin notice for the current user.
+ *
+ * The handler only ever stashes EITHER a notice (success/duplicate paths) OR form
+ * state (validation/create errors), never both — so clearing the whole transient
+ * here is safe and avoids leaking a refreshed TTL across page reloads.
+ *
+ * @since TBD
+ */
+function pmprogroupacct_admin_groups_render_notice() {
+	$key   = 'pmprogroupacct_admin_form_' . get_current_user_id();
+	$state = get_transient( $key );
+	if ( empty( $state['notice']['message'] ) ) {
+		return;
+	}
+	delete_transient( $key );
+
+	$notice = $state['notice'];
+	$type   = isset( $notice['type'] ) ? $notice['type'] : 'success';
+	$class  = 'success' === $type ? 'notice-success' : ( 'warning' === $type ? 'notice-warning' : 'notice-error' );
+	printf( '<div class="notice %1$s is-dismissible"><p>%2$s</p></div>', esc_attr( $class ), esc_html( $notice['message'] ) );
+}
+
+/**
+ * Stash form state (inputs + errors + optional notice) so the redirect target can re-render.
+ * Single-use, scoped to the current user, 60-second TTL.
+ *
+ * @since TBD
+ */
+function pmprogroupacct_admin_groups_set_form_state( $state ) {
+	set_transient( 'pmprogroupacct_admin_form_' . get_current_user_id(), $state, 60 );
+}
+
+/**
+ * Stash a "group already exists" notice and redirect to the frontend manage-group
+ * page for the given group. Falls back to the list view if the frontend page isn't set.
+ *
+ * Exits.
+ *
+ * @since TBD
+ */
+function pmprogroupacct_admin_groups_redirect_to_existing_group( $existing_group ) {
+	pmprogroupacct_admin_groups_set_form_state( array(
+		'notice' => array(
+			'type'    => 'warning',
+			'message' => __( 'A group already exists for that user and level. Opening the existing group.', 'pmpro-group-accounts' ),
+		),
+	) );
+	$manage_group_url = pmpro_url( 'pmprogroupacct_manage_group' );
+	$redirect_url     = ! empty( $manage_group_url ) ? add_query_arg( 'pmprogroupacct_group_id', $existing_group->id, $manage_group_url ) : pmprogroupacct_admin_groups_url();
+	wp_safe_redirect( $redirect_url );
+	exit;
+}
+
+/**
+ * Read and clear the stashed form state.
+ *
+ * @since TBD
+ */
+function pmprogroupacct_admin_groups_consume_form_state() {
+	$key   = 'pmprogroupacct_admin_form_' . get_current_user_id();
+	$state = get_transient( $key );
+	if ( empty( $state ) ) {
+		return array();
+	}
+	delete_transient( $key );
+	return is_array( $state ) ? $state : array();
+}

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -38,6 +38,27 @@ function pmprogroupacct_admin_notice() {
 add_action( 'admin_notices', 'pmprogroupacct_admin_notice' );
 
 /**
+ * Register the Group Accounts admin page under the Memberships menu.
+ *
+ * @since TBD
+ */
+function pmprogroupacct_add_admin_menu() {
+	if ( ! defined( 'PMPRO_VERSION' ) || ! function_exists( 'pmpro_get_edit_member_capability' ) ) {
+		return;
+	}
+
+	add_submenu_page(
+		'pmpro-dashboard',
+		__( 'Group Accounts', 'pmpro-group-accounts' ),
+		__( 'Group Accounts', 'pmpro-group-accounts' ),
+		pmpro_get_edit_member_capability(),
+		'pmpro-groupacct-groups',
+		'pmprogroupacct_admin_groups_page'
+	);
+}
+add_action( 'admin_menu', 'pmprogroupacct_add_admin_menu' );
+
+/**
  * Show a message if Paid Memberships Pro is inactive or not installed.
  */
 function pmprogroupacct_required_installed() {

--- a/includes/edit-member.php
+++ b/includes/edit-member.php
@@ -69,12 +69,30 @@ function pmprogroupacct_show_group_account_info( $user ) {
 	);
 	$group_members = PMProGroupAcct_Group_Member::get_group_members( $group_member_query_args );
 
+	// Find parent-eligible levels the user holds that do not yet have a group,
+	// so we can offer a "Create Group" link for each one.
+	$levels_without_groups     = array();
+	$user_levels               = pmpro_getMembershipLevelsForUser( $user->ID );
+	$existing_parent_level_ids = $groups ? array_map( 'intval', wp_list_pluck( $groups, 'group_parent_level_id' ) ) : array();
+	foreach ( (array) $user_levels as $user_level ) {
+		$level_settings = pmprogroupacct_get_settings_for_level( $user_level->id );
+		if ( empty( $level_settings ) || empty( $level_settings['child_level_ids'] ) ) {
+			continue;
+		}
+		if ( in_array( (int) $user_level->id, $existing_parent_level_ids, true ) ) {
+			continue;
+		}
+		$levels_without_groups[] = $user_level;
+	}
+
 	// Show the UI.
 	?>
 	<h3><?php esc_html_e( 'Manage Groups', 'pmpro-group-accounts' ); ?></h3>
 	<?php
 	if ( empty( $groups ) ) {
-		echo '<p>' . esc_html__( 'This user does not manage any groups.', 'pmpro-group-accounts' ) . '</p>';
+		if ( empty( $levels_without_groups ) ) {
+			echo '<p>' . esc_html__( 'This user does not manage any groups.', 'pmpro-group-accounts' ) . '</p>';
+		}
 	} else {
 		// Show the groups that the user manages.
 		?>
@@ -105,8 +123,9 @@ function pmprogroupacct_show_group_account_info( $user ) {
 						<td>
 						<?php
 							$group_settings = pmprogroupacct_get_settings_for_level( $group->group_parent_level_id );
+							$child_level_ids = ! empty( $group_settings['child_level_ids'] ) ? $group_settings['child_level_ids'] : array();
 							$child_level_links = array();
-							foreach ( $group_settings['child_level_ids'] as $child_level_id ) {
+							foreach ( $child_level_ids as $child_level_id ) {
 								if ( ! empty( $pmpro_pages['checkout'] ) ) {
 									$child_level = pmpro_getLevel( $child_level_id );
 									$child_level_links[] = '<a target="_blank" href="' . esc_url( add_query_arg( array( 'level' => $child_level->id, 'pmprogroupacct_group_code' => $group->group_checkout_code ), pmpro_url( 'checkout' ) ) ) . '">' . esc_html( $child_level->name ) . '</a>';
@@ -138,8 +157,28 @@ function pmprogroupacct_show_group_account_info( $user ) {
 				}
 				?>
 			</tbody>
-		</table> 
+		</table>
 		<?php
+	}
+
+	// "Create Group" link per parent-eligible level the user holds without a group.
+	if ( ! empty( $levels_without_groups ) ) {
+		foreach ( $levels_without_groups as $level_without_group ) {
+			$create_url = pmprogroupacct_admin_groups_url( array(
+				'action'          => 'add',
+				'parent_user_id'  => (int) $user->ID,
+				'parent_level_id' => (int) $level_without_group->id,
+			) );
+			?>
+			<p>
+				<?php
+				/* translators: %s: parent membership level name */
+				echo esc_html( sprintf( __( 'This user holds the %s parent level but does not have a group yet.', 'pmpro-group-accounts' ), $level_without_group->name ) );
+				echo ' <a href="' . esc_url( $create_url ) . '">' . esc_html__( 'Create Group', 'pmpro-group-accounts' ) . '</a>';
+				?>
+			</p>
+			<?php
+		}
 	}
 	?>
 	<h3><?php esc_html_e( 'Manage Child Memberships', 'pmpro-group-accounts' ); ?></h3>

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -72,3 +72,44 @@ function pmprogroupacct_member_edit_url_for_user( $user ) {
 	// Return the parent user edit URL.
 	return $member_edit_url;
 }
+
+/**
+ * Build a URL to the Group Accounts admin page, optionally with query args
+ * for action / parent_user_id / parent_level_id prefill.
+ *
+ * @since TBD
+ *
+ * @param array $args Optional query args to append.
+ * @return string
+ */
+function pmprogroupacct_admin_groups_url( $args = array() ) {
+	return add_query_arg(
+		array_merge( array( 'page' => 'pmpro-groupacct-groups' ), $args ),
+		admin_url( 'admin.php' )
+	);
+}
+
+/**
+ * Return the list of membership level objects that are configured as parent
+ * levels for group accounts (i.e. their `pmprogroupacct_settings` has at least
+ * one entry in `child_level_ids`).
+ *
+ * @since TBD
+ *
+ * @return array Indexed array of level objects from pmpro_getAllLevels().
+ */
+function pmprogroupacct_get_parent_eligible_levels() {
+	if ( ! function_exists( 'pmpro_getAllLevels' ) ) {
+		return array();
+	}
+
+	$all_levels   = pmpro_getAllLevels( true, true );
+	$parent_levels = array();
+	foreach ( $all_levels as $level ) {
+		$settings = pmprogroupacct_get_settings_for_level( $level->id );
+		if ( ! empty( $settings ) && ! empty( $settings['child_level_ids'] ) ) {
+			$parent_levels[] = $level;
+		}
+	}
+	return $parent_levels;
+}

--- a/includes/parents.php
+++ b/includes/parents.php
@@ -333,14 +333,7 @@ function pmprogroupacct_pmpro_after_all_membership_level_changes_parent( $old_us
 
 		// Get the new level for this user.
 		$new_levels    = pmpro_getMembershipLevelsForUser( $user_id );
-		$new_level_ids = wp_list_pluck( $new_levels, 'id' );		
-
-		// Make sure the user has a group for any group parent levels they gained.
-		$received_level_ids = array_diff( $new_level_ids, $old_level_ids );
-		foreach ( $received_level_ids as $received_level_id ) {
-			pmprogroupacct_create_free_group_if_needed( $user_id, $received_level_id );
-		}
-
+		$new_level_ids = wp_list_pluck( $new_levels, 'id' );
 
 		// Check if the parent has a group for any of the levels they lost.
 		$lost_level_ids = array_diff( $old_level_ids, $new_level_ids );
@@ -438,62 +431,3 @@ function pmprogroupacct_pmpro_invoice_bullets_bottom_parent( $invoice ) {
 }
 add_action( 'pmpro_invoice_bullets_bottom', 'pmprogroupacct_pmpro_invoice_bullets_bottom_parent' );
 
-/**
- * When a user logs in, check if they have all needed groups for their levels.
- * If not, create empty groups for them.
- *
- * @since 1.0.1
- *
- * @param string $user_login The user's login.
- * @param WP_User $user The user object.
- */
-function pmprogroupacct_wp_login_parent( $user_login, $user ) {
-	// Make sure that PMPro is enabled.
-	if ( ! function_exists( 'pmpro_getMembershipLevelsForUser' ) ) {
-		return;
-	}
-
-	// Get the user's levels.
-	$levels = pmpro_getMembershipLevelsForUser( $user->ID );
-
-	// Loop through the user's levels and create empty groups if needed.
-	foreach ( $levels as $level ) {
-		pmprogroupacct_create_free_group_if_needed( $user->ID, $level->id );
-	}
-}
-add_action( 'wp_login', 'pmprogroupacct_wp_login_parent', 10, 2 );
-
-
-/**
- * Creates an "free" group if needed for a given parent user and level.
- *
- * A "free" group is a new, empty group that is created with the maximum number
- * of free seats for the level. We do not want to give paid seats to a group
- * until the user has completed checkout and paid for them.
- *
- * @since 1.0.1
- *
- * @param int $user_id The ID of the parent user.
- * @param int $level_id The ID of the level.
- */
-function pmprogroupacct_create_free_group_if_needed( $user_id, $level_id ) {
-	// Get the group settings for this level.
-	$settings = pmprogroupacct_get_settings_for_level( $level_id );
-
-	// If there are no settings, then this is not a group parent level. Bail.
-	if ( empty( $settings ) ) {
-		return;
-	}
-
-	// Check if there is already a group for this user and level.
-	$existing_group = PMProGroupAcct_Group::get_group_by_parent_user_id_and_parent_level_id( $user_id, $level_id );
-	if ( ! empty( $existing_group ) ) {
-		return;
-	}
-
-	// Create a group for this user and level.
-	// If the pricing model is free, give them the max seats.
-	// Otherwise, give them them 0. The `pmpro_after_checkout` filter will update the seats at chekout if needed.
-	$seats = ( $settings['pricing_model'] === 'none' ) ? $settings['max_seats'] : 0;
-	PMProGroupAcct_Group::create( $user_id, $level_id, $seats );
-}

--- a/pmpro-group-accounts.php
+++ b/pmpro-group-accounts.php
@@ -17,9 +17,11 @@ define( 'PMPROGROUPACCT_VERSION', '1.5.2' );
 
 include_once( PMPROGROUPACCT_DIR . '/classes/class-pmprogroupacct-group.php' );
 include_once( PMPROGROUPACCT_DIR . '/classes/class-pmprogroupacct-group-member.php' );
+include_once( PMPROGROUPACCT_DIR . '/classes/class-pmprogroupacct-groups-list-table.php' );
 
 include_once( PMPROGROUPACCT_DIR . '/includes/functions.php' );
 include_once( PMPROGROUPACCT_DIR . '/includes/admin.php' );
+include_once( PMPROGROUPACCT_DIR . '/includes/admin-groups.php' );
 include_once( PMPROGROUPACCT_DIR . '/includes/scripts.php' );
 include_once( PMPROGROUPACCT_DIR . '/includes/emails.php' );
 include_once( PMPROGROUPACCT_DIR . '/includes/edit-level.php' );


### PR DESCRIPTION
## Summary

Adds a new admin page at **Memberships → Group Accounts** so admins can list every group on the site and create groups manually. Removes the old auto-create code path, which silently created empty 0-seat groups on level gain or on every parent login — group creation is now strictly checkout or explicit admin action.

### List view
WP_List_Table with Group ID (linked to the frontend manage-group page), Parent Account, Parent Level, Group Code, Seats (active/total), and Status badge. Parent Level + Status filter dropdowns above the table. Status is derived from whether the parent currently holds the parent level (same predicate as `is_accepting_signups`), implemented via a `LEFT JOIN pmpro_memberships_users` so pagination stays correct.

### Add Group form
Text input for parent user (accepts either email or login; server-side resolves email first, then login, so users with email-shaped logins are reachable), parent level dropdown of all parent-eligible levels, seat count. Validates the parent currently holds the chosen level. Redirects to the existing manage-group page when a (parent_user, parent_level) pair already has a group.

### Edit Member panel
When a user holds a parent-eligible level but doesn't have a group for it yet, a "Create Group" link now appears for each such level, pointing at the new page with `parent_user_id` and `parent_level_id` prefilled.

### Removed behavior
- `pmprogroupacct_create_free_group_if_needed` helper
- `pmprogroupacct_wp_login_parent` and its `wp_login` hook
- The received-level branch in `pmprogroupacct_pmpro_after_all_membership_level_changes_parent` that called the helper

Existing 0-seat junk rows are left in place; admins can triage them via the new list view.

### Extension hooks
- `pmprogroupacct_manage_groupslist_columns` filter — add/remove columns.
- `pmprogroupacct_manage_grouplist_custom_column` action — render the column body (callbacks echo their own escaped HTML).

Naming matches PMPro core's plural-list / singular-list pattern (`pmpro_manage_orderslist_columns` / `pmpro_manage_orderlist_custom_column`, etc.).

### Model changes
`PMProGroupAcct_Group::get_groups()` gains `offset`, `return_count`, and `status` arguments to support pagination, count queries, and the status filter. DISTINCT is only applied when the status JOIN is present (the base table's UNIQUE keys make it unnecessary otherwise).

## Test plan
- [ ] Memberships → Group Accounts loads; list shows all groups with all columns populated.
- [ ] Parent Level + Status filters narrow results correctly; sort by each sortable column works.
- [ ] `?paged=N` past the end of the result set clamps to the last actual page (no spurious "No groups found").
- [ ] Add New Group with username → creates group, redirects to list with success notice.
- [ ] Add New Group with email → same.
- [ ] Add New Group with a user who has an email-shaped login but different email → resolves to the login user.
- [ ] Add New Group for a user/level that already has a group → warning notice + redirect to the existing manage-group page.
- [ ] Add New Group with a user who doesn't hold the chosen parent level → inline error, form re-renders with inputs preserved.
- [ ] Edit Member panel: user with a parent-eligible level and no group shows the "Create Group" link with the right prefill.
- [ ] No more auto-created 0-seat groups on `wp_login` or on admin-granted parent-level changes.
- [ ] Free fixed-seat parent level via checkout still creates a group with the chosen seats.
- [ ] Paid parent level via checkout still creates a group with the purchased seats.
- [ ] `pmprogroupacct_manage_groupslist_columns` + `pmprogroupacct_manage_grouplist_custom_column` work for a custom column added via a small mu-plugin.
