### PR TITLE
Repair broken sort

### DIFF
--- a/classes/class-pmprogroupacct-group.php
+++ b/classes/class-pmprogroupacct-group.php
@@ -101,7 +101,7 @@ class PMProGroupAcct_Group {
 		$status   = isset( $args['status'] ) && in_array( strtolower( (string) $args['status'] ), array( 'active', 'inactive' ), true ) ? strtolower( $args['status'] ) : '';
 
 		// Detect unsupported orderby usage.
-		if ( $orderby !== preg_replace( '/[^a-zA-Z0-9\s,`]/', ' ', $orderby ) ) {
+		if ( $orderby !== preg_replace( '/[^a-zA-Z0-9_\s,`]/', ' ', $orderby ) ) {
 			return empty( $args['return_count'] ) ? array() : 0;
 		}
 


### PR DESCRIPTION
The character class [^a-zA-Z0-9\s,]is missing_(underscore). Every sortable column *except*id maps to an orderby value with an underscore. Without a fix, returns blank when trying to sort.

