### PR TITLE
Fix inverted seat check in the create member flow

### DIFF
--- a/includes/manage-group-page.php
+++ b/includes/manage-group-page.php
@@ -449,7 +449,7 @@ function pmprogroupacct_shortcode_manage_group() {
 		}
 
 		// Make sure that there is an available seat in the group.
-		if ( ! empty( $create_member_message ) && $group->is_accepting_signups() ) {
+		if ( empty( $create_member_message ) && ! $group->is_accepting_signups() ) {
 			$create_member_message = '<div class="' . pmpro_get_element_class( 'pmpro_message pmpro_error' ) . '">' . esc_html__( 'No available seats in this group.', 'pmpro-group-accounts' ) . '</div>';
 		}
 


### PR DESCRIPTION
The seat-availability check on the Manage Group page's create-member form was doubly inverted:

```php
if ( ! empty( $create_member_message ) && $group->is_accepting_signups() ) {
```

It only set the "No available seats" error when an error message **already existed** and the group **was** accepting signups — so when a group was full and the form was otherwise valid, no error was set and `wp_create_user()` + the level change proceeded past the seat limit.

Fixed to:

```php
if ( empty( $create_member_message ) && ! $group->is_accepting_signups() ) {
```

**Testing:** fill a group to its seat limit, then submit the create-member form as the group parent — should show "No available seats in this group." and create no user. With seats available, creation works as before.